### PR TITLE
fixed yunet.py

### DIFF
--- a/models/face_detection_yunet/yunet.py
+++ b/models/face_detection_yunet/yunet.py
@@ -19,7 +19,7 @@ class YuNet:
         self._backendId = backendId
         self._targetId = targetId
 
-        self._model = cv.FaceDetectorYN.create(
+        self._model = cv.FaceDetectorYN_create(
             model=self._modelPath,
             config="",
             input_size=self._inputSize,
@@ -35,7 +35,7 @@ class YuNet:
 
     def setBackend(self, backendId):
         self._backendId = backendId
-        self._model = cv.FaceDetectorYN.create(
+        self._model = cv.FaceDetectorYN_create(
             model=self._modelPath,
             config="",
             input_size=self._inputSize,
@@ -47,7 +47,7 @@ class YuNet:
 
     def setTarget(self, targetId):
         self._targetId = targetId
-        self._model = cv.FaceDetectorYN.create(
+        self._model = cv.FaceDetectorYN_create(
             model=self._modelPath,
             config="",
             input_size=self._inputSize,


### PR DESCRIPTION
I found that `face_detection_yunet/yunet.py` uses `cv2.FaceDetectorYN.create`.  
<https://github.com/opencv/opencv_zoo/blob/365c419a67bfdd590bff61f46084b9a42afad18a/models/face_detection_yunet/yunet.py>

But, I think that this script shoud use `cv2.FaceDetectorYN_create`.  
<https://docs.opencv.org/4.5.4/df/d20/classcv_1_1FaceDetectorYN.html#a42293cf2d64f8b69a707ab70d11925b3>