### PR TITLE
Update benchermark and quantize

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -20,12 +20,20 @@ Time is measured from data preprocess (resize is excluded), to a forward pass of
 Run the following command to benchmark on a given config:
 
 ```shell
-PYTHONPATH=.. python benchmark.py --cfg ./config/face_detection_yunet.yaml
+export PYTHONPATH=$PYTHONPATH:.. 
+python benchmark.py --cfg ./config/face_detection_yunet.yaml
 ```
 
 If you are a Windows user and wants to run in CMD/PowerShell, use this command instead:
+- CMD
 ```shell
-set PYTHONPATH=..
+set PYTHONPATH=%PYTHONPATH%;..
+python benchmark.py --cfg ./config/face_detection_yunet.yaml
+```
+
+- PowerShell
+```shell
+$env:PYTHONPATH=$env:PYTHONPATH+";.."
 python benchmark.py --cfg ./config/face_detection_yunet.yaml
 ```
 <!--

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -30,7 +30,7 @@ def prepend_pythonpath(cfg):
             prepend_pythonpath(v)
         else:
             if 'path' in k.lower():
-                cfg[k] = os.path.join(os.environ['PYTHONPATH'], v)
+                cfg[k] = os.path.join(os.environ['PYTHONPATH'].split(os.pathsep)[-1], v)
 
 class Benchmark:
     def __init__(self, **kwargs):

--- a/tools/quantize/requirements.txt
+++ b/tools/quantize/requirements.txt
@@ -1,4 +1,5 @@
 opencv-python>=4.5.4.58
 onnx
 onnxruntime
+onnxruntime-extensions
 neural-compressor


### PR DESCRIPTION
- Add the command for setting `PYTHONPATH` in powershell
- Let benchmark use the last path of environment
- Intel neural-compressor need  `onnxruntime-extensions`