### PR TITLE
Fix variable name error in yolox.py/setBackend

### DIFF
--- a/models/object_detection_yolox/yolox.py
+++ b/models/object_detection_yolox/yolox.py
@@ -23,7 +23,7 @@ class YoloX:
     def name(self):
         return self.__class__.__name__
 
-    def setBackend(self, backenId):
+    def setBackend(self, backendId):
         self.backendId = backendId
         self.net.setPreferableBackend(self.backendId)
 


### PR DESCRIPTION
Fix variable name error in yolox.py/setBackend