### PR TITLE
Fix a bug in yolox when there are no acceptable objects

### DIFF
--- a/models/object_detection_yolox/README.md
+++ b/models/object_detection_yolox/README.md
@@ -22,6 +22,7 @@ python demo.py --input /path/to/image
 ```
 Note: 
 - image result saved as "result.jpg"
+- this model requires `opencv-python>=4.7.0`
 
 
 ## Results
@@ -56,7 +57,7 @@ The model is evaluated on [COCO 2017 val](https://cocodataset.org/#download). Re
 
  </td><td>
 
-  area  |  IoU  |  Average Recall(AR)  |
+|   area |  IoU  |  Average Recall(AR)  |
 |:-------|:------|:----------------|
 |  all  |  0.50:0.95  |  0.326  |
 |  all  |  0.50:0.95  |  0.531  |

--- a/models/object_detection_yolox/yolox.py
+++ b/models/object_detection_yolox/yolox.py
@@ -63,13 +63,11 @@ class YoloX:
         max_scores = np.amax(scores, axis=1)
         max_scores_idx = np.argmax(scores, axis=1)
 
-        # batched-nms, TODO: replace with cv2.dnn.NMSBoxesBatched when OpenCV 4.7.0 is released
-        max_coord = boxes_xyxy.max()
-        offsets = max_scores_idx * (max_coord + 1)
-        boxes_for_nms = boxes_xyxy + offsets[:, None]
-        keep = cv2.dnn.NMSBoxes(boxes_for_nms.tolist(), max_scores.tolist(), self.confThreshold, self.nmsThreshold)
+        keep = cv2.dnn.NMSBoxesBatched(boxes_xyxy.tolist(), max_scores.tolist(), max_scores_idx.tolist(), self.confThreshold, self.nmsThreshold)
 
         candidates = np.concatenate([boxes_xyxy, max_scores[:, None], max_scores_idx[:, None]], axis=1)
+        if len(keep) == 0:
+            return np.array([])
         return candidates[keep]
 
     def generateAnchors(self):


### PR DESCRIPTION
When there are no acceptable objects in the image, yolox returns 8400 results. This PR fixes this problem.