### PR TITLE
removed extra key in models.crnn dictionary

### DIFF
--- a/tools/eval/eval.py
+++ b/tools/eval/eval.py
@@ -76,8 +76,7 @@ models = dict(
     crnn=dict(
         name="CRNN",
         topic="text_recognition",
-        modelPath=os.path.join(root_dir, "models/text_recognition_crnn/text_recognition_CRNN_EN_2021sep.onnx"),
-        charsetPath=os.path.join(root_dir, "models/text_recognition_crnn/charset_36_EN.txt")),
+        modelPath=os.path.join(root_dir, "models/text_recognition_crnn/text_recognition_CRNN_EN_2021sep.onnx")),
 )
 
 datasets = dict(


### PR DESCRIPTION
Resolves #125 
This is caused by an extra key present in the `models` dictionary in `tools/eval/eval.py`
![image](https://user-images.githubusercontent.com/94868003/215845552-534ef2a3-7b5c-4f2e-8327-234b7b0f6da8.png)

removing this key fixes the issue, the CRNN constructor does not expect a `charsetPath` argument.
The script runs successfully after this change.

output of `python eval.py -m crnn -d icdar -dr /path/to/icdar` : 

Evaluating CRNN with ICDAR val set: 100%|█████████████████████████████████████████████████████████████████████████| 1156/1156 [00:24<00:00, 46.52it/s]
Accuracy: 81.66%