### PR TITLE
Update FER quantized model and fix document

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Some examples are listed below. You can find more in the directory of each model
 
 ![largest selfie](./models/face_detection_yunet/examples/largest_selfie.jpg)
 
-### Facial Expression Recognition with Progressive Teacher(./models/facial_expression_recognition/)
+### Facial Expression Recognition with [Progressive Teacher](./models/facial_expression_recognition/)
 
 ![fer demo](./models/facial_expression_recognition/examples/selfie.jpg)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Guidelines:
 | ------------------------------------------------------- | ----------------------------- | ---------- | -------------- | ------------ | --------------- | ------------ | ----------- |
 | [YuNet](./models/face_detection_yunet)                  | Face Detection                | 160x120    | 1.45           | 6.22         | 12.18           | 4.04         | 86.69       |
 | [SFace](./models/face_recognition_sface)                | Face Recognition              | 112x112    | 8.65           | 99.20        | 24.88           | 46.25        | ---         |
-| [FER](./models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 4.43           | 49.86        | 31.07           | 108.53\*     | ---         |
+| [FER](./models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 4.43           | 49.86        | 31.07           | 29.80        | ---         |
 | [LPD-YuNet](./models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | ---            | 168.03       | 56.12           | 29.53        | ---         |
 | [YOLOX](./models/object_detection_yolox/)               | Object Detection              | 640x640    | 176.68         | 1496.70      | 388.95          | 420.98       | ---         |
 | [NanoDet](./models/object_detection_nanodet/)           | Object Detection              | 416x416    | 157.91         | 220.36       | 64.94           | 116.64       | ---         |

--- a/models/facial_expression_recognition/README.md
+++ b/models/facial_expression_recognition/README.md
@@ -6,7 +6,7 @@ Progressive Teacher: [Boosting Facial Expression Recognition by A Semi-Supervise
 Note:
 - Progressive Teacher is contributed by [Jing Jiang](https://scholar.google.com/citations?user=OCwcfAwAAAAJ&hl=zh-CN).
 -  [MobileFaceNet](https://link.springer.com/chapter/10.1007/978-3-319-97909-0_46) is used as the backbone and the model is able to classify seven basic facial expressions (angry, disgust, fearful, happy, neutral, sad, surprised).
-- [facial_expression_recognition_mobilefacenet_2022july.onnx](https://github.com/opencv/opencv_zoo/raw/master/models/facial_expression_recognition/facial_expression_recognition_mobilefacenet_2022july.onnx) is implemented thanks to [Chengrui Wang](https://github.com/opencv).
+- [facial_expression_recognition_mobilefacenet_2022july.onnx](https://github.com/opencv/opencv_zoo/raw/master/models/facial_expression_recognition/facial_expression_recognition_mobilefacenet_2022july.onnx) is implemented thanks to [Chengrui Wang](https://github.com/crywang).
 
 Results of accuracy evaluation on [RAF-DB](http://whdeng.cn/RAF/model1.html).
 

--- a/models/facial_expression_recognition/demo.py
+++ b/models/facial_expression_recognition/demo.py
@@ -35,7 +35,7 @@ except:
 
 parser = argparse.ArgumentParser(description='Facial Expression Recognition')
 parser.add_argument('--input', '-i', type=str, help='Path to the input image. Omit for using default camera.')
-parser.add_argument('--model', '-fm', type=str, default='./facial_expression_recognition_mobilefacenet_2022july.onnx', help='Path to the facial expression recognition model.')
+parser.add_argument('--model', '-m', type=str, default='./facial_expression_recognition_mobilefacenet_2022july.onnx', help='Path to the facial expression recognition model.')
 parser.add_argument('--backend', '-b', type=int, default=backends[0], help=help_msg_backends.format(*backends))
 parser.add_argument('--target', '-t', type=int, default=targets[0], help=help_msg_targets.format(*targets))
 parser.add_argument('--save', '-s', type=str, default=False, help='Set true to save results. This flag is invalid when using camera.')

--- a/models/facial_expression_recognition/facial_expression_recognition_mobilefacenet_2022july-int8-quantized.onnx
+++ b/models/facial_expression_recognition/facial_expression_recognition_mobilefacenet_2022july-int8-quantized.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:541597ca330e0e3babe883d0fa6ab121b0e3da65c9cc099c05ff274b3106a658
-size 1340132
+oid sha256:f0d7093aff10e2638c734c5f18a6a7eabd2b9239b20bdb9b8090865a6f69a1ed
+size 1364007

--- a/tools/quantize/inc_configs/fer.yaml
+++ b/tools/quantize/inc_configs/fer.yaml
@@ -17,9 +17,21 @@ quantization:                                        # optional. tuning constrai
           dtype: float32
           label: True
 
+  model_wise:                                        # optional. tuning constraints on model-wise for advance user to reduce tuning space.
+    weight:
+      granularity: per_tensor
+      scheme: asym
+      dtype: int8
+      algorithm: minmax
+    activation:
+      granularity: per_tensor
+      scheme: asym
+      dtype: int8
+      algorithm: minmax
+
 tuning:
   accuracy_criterion:
-    relative:  0.01                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 1%.
+    relative:  0.02                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 1%.
   exit_policy:
     timeout: 0                                       # optional. tuning timeout (seconds). default value is 0 which means early stop. combine with max_trials field to decide when to exit.
     max_trials: 50                                   # optional. max tune times. default value is 100. combine with timeout field to decide when to exit.


### PR DESCRIPTION
This PR try to quantize `FER` model in `per_tensor` mode. Since the accuracy evaluation dataset has 350 images, the quantize loss should be relaxed. I changed it from `0.01` to `0.02` and then got a acceptable quantized model. 

The accuracy of the current model in the quantize evaluation dataset is `int8|fp32: 0.7457|0.7571`, which is only droped a little. But the time cost in `KV3-NPU` is changed **from 108.53ms to 29.80ms**!