### PR TITLE
move setting description outside for loop in evaluation scripts

### DIFF
--- a/tools/eval/datasets/icdar.py
+++ b/tools/eval/datasets/icdar.py
@@ -33,8 +33,9 @@ class ICDAR:
     def eval(self, model):
         right_num = 0
         pbar = tqdm(self.val_label)
+        pbar.set_description("Evaluating {} with {} val set".format(model.name, self.name))
+
         for fn, label in pbar:
-            pbar.set_description("Evaluating {} with {} val set".format(model.name, self.name))
 
             img = cv.imread(fn)
 

--- a/tools/eval/datasets/iiit5k.py
+++ b/tools/eval/datasets/iiit5k.py
@@ -36,8 +36,9 @@ class IIIT5K:
     def eval(self, model):
         right_num = 0
         pbar = tqdm(self.val_label)
+        pbar.set_description("Evaluating {} with {} val set".format(model.name, self.name))
+
         for img, value in pbar:
-            pbar.set_description("Evaluating {} with {} val set".format(model.name, self.name))
 
 
             rbbox = np.array([0, img.shape[0], 0, 0, img.shape[1], 0, img.shape[1], img.shape[0]])

--- a/tools/eval/datasets/imagenet.py
+++ b/tools/eval/datasets/imagenet.py
@@ -39,8 +39,9 @@ class ImageNet:
         top_1_hits = 0
         top_5_hits = 0
         pbar = tqdm(self.val_label)
+        pbar.set_description("Evaluating {} with {} val set".format(model.name, self.name))
+
         for fn, label in pbar:
-            pbar.set_description("Evaluating {} with {} val set".format(model.name, self.name))
 
             img = cv.imread(fn)
             img = cv.cvtColor(img, cv.COLOR_BGR2RGB)


### PR DESCRIPTION
This PR moves the `pbar.set_description` line outside of the for loop as discussed [here](https://github.com/opencv/opencv_zoo/pull/130#discussion_r1105252865) in  the following evaluation scripts : 
- [icdar.py](https://github.com/opencv/opencv_zoo/blob/6c68bc48c6f96042b29b3425174e431ccac38376/tools/eval/datasets/icdar.py#L37)
- [imagenet.py](https://github.com/opencv/opencv_zoo/blob/6c68bc48c6f96042b29b3425174e431ccac38376/tools/eval/datasets/imagenet.py#L43)
- [iiitk5.py](https://github.com/opencv/opencv_zoo/blob/6c68bc48c6f96042b29b3425174e431ccac38376/tools/eval/datasets/iiit5k.py#L40)
