### PR TITLE
replace pphumanseg with a simplified one

### DIFF
--- a/models/human_segmentation_pphumanseg/demo.py
+++ b/models/human_segmentation_pphumanseg/demo.py
@@ -33,7 +33,7 @@ except:
 
 parser = argparse.ArgumentParser(description='PPHumanSeg (https://github.com/PaddlePaddle/PaddleSeg/tree/release/2.2/contrib/PP-HumanSeg)')
 parser.add_argument('--input', '-i', type=str, help='Usage: Set input path to a certain image, omit if using camera.')
-parser.add_argument('--model', '-m', type=str, default='human_segmentation_pphumanseg_2021oct.onnx', help='Usage: Set model path, defaults to human_segmentation_pphumanseg_2021oct.onnx.')
+parser.add_argument('--model', '-m', type=str, default='human_segmentation_pphumanseg_2023mar.onnx', help='Usage: Set model path, defaults to human_segmentation_pphumanseg_2023mar.onnx.')
 parser.add_argument('--backend', '-b', type=int, default=backends[0], help=help_msg_backends.format(*backends))
 parser.add_argument('--target', '-t', type=int, default=targets[0], help=help_msg_targets.format(*targets))
 parser.add_argument('--save', '-s', type=str, default=False, help='Usage: Set “True” to save a file with results. Invalid in case of camera input. Default will be set to “False”.')
@@ -153,4 +153,3 @@ if __name__ == '__main__':
             cv.imshow('PPHumanSeg Demo', frame)
 
             tm.reset()
-

--- a/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct-act_int8-wt_int8-quantized.onnx
+++ b/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct-act_int8-wt_int8-quantized.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7f4ae288d187383b616938e2d5d481e8f040d35534856ba834b0121aee08cb2
-size 1625110

--- a/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct.onnx
+++ b/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:307dcfce41e793c8440b2a66b953c977fe3103a1c46babd56d06a9312eb2b92f
-size 6249491

--- a/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar-act_int8-wt_int8-quantized.onnx
+++ b/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar-act_int8-wt_int8-quantized.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:510775a9e23c1a53c34013a2fa3ac1906bfd7b789d55c07e6b49f30bb669007d
+size 1607872

--- a/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar.onnx
+++ b/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:552d8a984054e59b5d773d24b9b12022b22046ceb2bbc4c9aaeaceb36a9ddf24
+size 6163938

--- a/tools/quantize/quantize-ort.py
+++ b/tools/quantize/quantize-ort.py
@@ -91,7 +91,7 @@ models=dict(
     sface=Quantize(model_path='../../models/face_recognition_sface/face_recognition_sface_2021dec.onnx',
                    calibration_image_dir='../../benchmark/data/face_recognition',
                    transforms=Compose([Resize(size=(112, 112))])),
-    pphumenseg=Quantize(model_path='../../models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct.onnx',
+    pphumanseg=Quantize(model_path='../../models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar.onnx',
                         calibration_image_dir='../../benchmark/data/human_segmentation',
                         transforms=Compose([Resize(size=(192, 192))])),
     ppresnet50=Quantize(model_path='../../models/image_classification_ppresnet/image_classification_ppresnet50_2022jan.onnx',


### PR DESCRIPTION
The model is downloaded following instructions from https://github.com/opencv/opencv/tree/4.x/samples/dnn/dnn_model_runner/dnn_conversion/paddlepaddle#2-run-paddleseg-portrait-segmentation-using-opencv

The model is ported from PaddlePaddle to ONNX with the following command:

```shell
paddle2onnx --model_dir humanseg_hrnet18_small_v1 \
            --model_filename model.pdmodel \
            --params_filename model.pdiparams \
            --opset_version 11 \
            --save_file humanseg_hrnet18_tiny.onnx
```

paddle2onnx          1.0.5
paddlepaddle         2.4.1

And simplified with:
```shell
onnxsim --input-shape="1,3,192,192" humanseg_hrnet18_tiny.onnx human_segmentation_pphumanseg_2023mar.onnx
```

onnxsim 0.4.17