### PR TITLE
Refactor benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,25 +23,25 @@ Guidelines:
 
 | Model                                                   | Task                          | Input Size | CPU-INTEL (ms) | CPU-RPI (ms) | GPU-JETSON (ms) | NPU-KV3 (ms) | NPU-Ascend310 (ms) | CPU-D1 (ms) |
 | ------------------------------------------------------- | ----------------------------- | ---------- | -------------- | ------------ | --------------- | ------------ | ------------------ | ----------- |
-| [YuNet](./models/face_detection_yunet)                  | Face Detection                | 160x120    | 1.45           | 5.43         | 12.18           | 4.04         | 1.73               | 86.69       |
-| [SFace](./models/face_recognition_sface)                | Face Recognition              | 112x112    | 8.65           | 78.83        | 24.88           | 46.25        | 23.17              | ---         |
-| [FER](./models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 4.43           | 32.53        | 31.07           | 29.80        | 10.12              | ---         |
-| [LPD-YuNet](./models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | ---            | 167.70       | 56.12           | 29.53        | 8.70               | ---         |
-| [YOLOX](./models/object_detection_yolox/)               | Object Detection              | 640x640    | 176.68         | 1805.87      | 388.95          | 420.98       | 29.10              | ---         |
-| [NanoDet](./models/object_detection_nanodet/)           | Object Detection              | 416x416    | 157.91         | 225.10       | 64.94           | 116.64       | 35.97              | ---         |
-| [DB-IC15](./models/text_detection_db)                   | Text Detection                | 640x480    | 142.91         | 1862.75      | 208.41          | ---          | 229.74             | ---         |
-| [DB-TD500](./models/text_detection_db)                  | Text Detection                | 640x480    | 142.91         | 1878.45      | 210.51          | ---          | 247.29             | ---         |
-| [CRNN-EN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 50.21          | 278.11       | 196.15          | 125.30       | 101.03             | ---         |
-| [CRNN-CN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 73.52          | 297.48       | 239.76          | 166.79       | 136.41             | ---         |
-| [PP-ResNet](./models/image_classification_ppresnet)     | Image Classification          | 224x224    | 56.05          | 463.93       | 98.64           | 75.45        | 6.99               | ---         |
-| [MobileNet-V1](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 9.04           | 72.33        | 33.18           | 145.66\*     | 5.25               | ---         |
-| [MobileNet-V2](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 8.86           | 66.56        | 31.92           | 146.31\*     | 5.82               | ---         |
-| [PP-HumanSeg](./models/human_segmentation_pphumanseg)   | Human Segmentation            | 192x192    | 19.92          | 73.13        | 67.97           | 74.77        | 7.07               | ---         |
-| [WeChatQRCode](./models/qrcode_wechatqrcode)            | QR Code Detection and Parsing | 100x100    | 7.04           | 5.71         | ---             | ---          | ---                | ---         |
-| [DaSiamRPN](./models/object_tracking_dasiamrpn)         | Object Tracking               | 1280x720   | 36.15          | 712.94       | 76.82           | ---          | ---                | ---         |
-| [YoutuReID](./models/person_reid_youtureid)             | Person Re-Identification      | 128x256    | 35.81          | 625.56       | 90.07           | 44.61        | 5.69               | ---         |
-| [MP-PalmDet](./models/palm_detection_mediapipe)         | Palm Detection                | 192x192    | 11.09          | 86.83        | 83.20           | 33.81        | 21.59              | ---         |
-| [MP-HandPose](./models/handpose_estimation_mediapipe)   | Hand Pose Estimation          | 224x224    | 4.28           | 43.57        | 40.10           | 19.47        | 6.02               | ---         |
+| [YuNet](./models/face_detection_yunet)                  | Face Detection                | 160x120    | 0.72           | 5.43         | 12.18           | 4.04         | 1.73               | 86.69       |
+| [SFace](./models/face_recognition_sface)                | Face Recognition              | 112x112    | 6.04           | 78.83        | 24.88           | 46.25        | 23.17              | ---         |
+| [FER](./models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 3.16           | 32.53        | 31.07           | 29.80        | 10.12              | ---         |
+| [LPD-YuNet](./models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | 8.63           | 167.70       | 56.12           | 29.53        | 8.70               | ---         |
+| [YOLOX](./models/object_detection_yolox/)               | Object Detection              | 640x640    | 141.20         | 1805.87      | 388.95          | 420.98       | 29.10              | ---         |
+| [NanoDet](./models/object_detection_nanodet/)           | Object Detection              | 416x416    | 66.03          | 225.10       | 64.94           | 116.64       | 35.97              | ---         |
+| [DB-IC15](./models/text_detection_db) (EN)              | Text Detection                | 640x480    | 71.03          | 1862.75      | 208.41          | ---          | 229.74             | ---         |
+| [DB-TD500](./models/text_detection_db) (EN&CN)          | Text Detection                | 640x480    | 72.31          | 1878.45      | 210.51          | ---          | 247.29             | ---         |
+| [CRNN-EN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 20.16          | 278.11       | 196.15          | 125.30       | 101.03             | ---         |
+| [CRNN-CN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 23.07          | 297.48       | 239.76          | 166.79       | 136.41             | ---         |
+| [PP-ResNet](./models/image_classification_ppresnet)     | Image Classification          | 224x224    | 34.71          | 463.93       | 98.64           | 75.45        | 6.99               | ---         |
+| [MobileNet-V1](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 5.90           | 72.33        | 33.18           | 145.66\*     | 5.25               | ---         |
+| [MobileNet-V2](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 5.97           | 66.56        | 31.92           | 146.31\*     | 5.82               | ---         |
+| [PP-HumanSeg](./models/human_segmentation_pphumanseg)   | Human Segmentation            | 192x192    | 8.81           | 73.13        | 67.97           | 74.77        | 7.07               | ---         |
+| [WeChatQRCode](./models/qrcode_wechatqrcode)            | QR Code Detection and Parsing | 100x100    | 1.29           | 5.71         | ---             | ---          | ---                | ---         |
+| [DaSiamRPN](./models/object_tracking_dasiamrpn)         | Object Tracking               | 1280x720   | 29.05          | 712.94       | 76.82           | ---          | ---                | ---         |
+| [YoutuReID](./models/person_reid_youtureid)             | Person Re-Identification      | 128x256    | 30.39          | 625.56       | 90.07           | 44.61        | 5.69               | ---         |
+| [MP-PalmDet](./models/palm_detection_mediapipe)         | Palm Detection                | 192x192    | 6.29           | 86.83        | 83.20           | 33.81        | 21.59              | ---         |
+| [MP-HandPose](./models/handpose_estimation_mediapipe)   | Hand Pose Estimation          | 224x224    | 4.68           | 43.57        | 40.10           | 19.47        | 6.02               | ---         |
 
 \*: Models are quantized in per-channel mode, which run slower than per-tensor quantized models on NPU.
 

--- a/README.md
+++ b/README.md
@@ -23,25 +23,25 @@ Guidelines:
 
 | Model                                                   | Task                          | Input Size | CPU-INTEL (ms) | CPU-RPI (ms) | GPU-JETSON (ms) | NPU-KV3 (ms) | NPU-Ascend310 (ms) | CPU-D1 (ms) |
 | ------------------------------------------------------- | ----------------------------- | ---------- | -------------- | ------------ | --------------- | ------------ | ------------------ | ----------- |
-| [YuNet](./models/face_detection_yunet)                  | Face Detection                | 160x120    | 1.45           | 6.22         | 12.18           | 4.04         | 1.73               | 86.69       |
-| [SFace](./models/face_recognition_sface)                | Face Recognition              | 112x112    | 8.65           | 99.20        | 24.88           | 46.25        | 23.17              | ---         |
-| [FER](./models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 4.43           | 49.86        | 31.07           | 29.80        | 10.12              | ---         |
-| [LPD-YuNet](./models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | ---            | 168.03       | 56.12           | 29.53        | 8.70               | ---         |
-| [YOLOX](./models/object_detection_yolox/)               | Object Detection              | 640x640    | 176.68         | 1496.70      | 388.95          | 420.98       | 29.10              | ---         |
-| [NanoDet](./models/object_detection_nanodet/)           | Object Detection              | 416x416    | 157.91         | 220.36       | 64.94           | 116.64       | 35.97              | ---         |
-| [DB-IC15](./models/text_detection_db)                   | Text Detection                | 640x480    | 142.91         | 2835.91      | 208.41          | ---          | 229.74             | ---         |
-| [DB-TD500](./models/text_detection_db)                  | Text Detection                | 640x480    | 142.91         | 2841.71      | 210.51          | ---          | 247.29             | ---         |
-| [CRNN-EN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 50.21          | 234.32       | 196.15          | 125.30       | 101.03             | ---         |
-| [CRNN-CN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 73.52          | 322.16       | 239.76          | 166.79       | 136.41             | ---         |
-| [PP-ResNet](./models/image_classification_ppresnet)     | Image Classification          | 224x224    | 56.05          | 602.58       | 98.64           | 75.45        | 6.99               | ---         |
-| [MobileNet-V1](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 9.04           | 92.25        | 33.18           | 145.66\*     | 5.25               | ---         |
-| [MobileNet-V2](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 8.86           | 74.03        | 31.92           | 146.31\*     | 5.82               | ---         |
-| [PP-HumanSeg](./models/human_segmentation_pphumanseg)   | Human Segmentation            | 192x192    | 19.92          | 105.32       | 67.97           | 74.77        | 7.07               | ---         |
-| [WeChatQRCode](./models/qrcode_wechatqrcode)            | QR Code Detection and Parsing | 100x100    | 7.04           | 37.68        | ---             | ---          | ---                | ---         |
-| [DaSiamRPN](./models/object_tracking_dasiamrpn)         | Object Tracking               | 1280x720   | 36.15          | 705.48       | 76.82           | ---          | ---                | ---         |
-| [YoutuReID](./models/person_reid_youtureid)             | Person Re-Identification      | 128x256    | 35.81          | 521.98       | 90.07           | 44.61        | 5.69               | ---         |
-| [MP-PalmDet](./models/palm_detection_mediapipe)         | Palm Detection                | 192x192    | 11.09          | 63.79        | 83.20           | 33.81        | 21.59              | ---         |
-| [MP-HandPose](./models/handpose_estimation_mediapipe)   | Hand Pose Estimation          | 224x224    | 4.28           | 36.19        | 40.10           | 19.47        | 6.02               | ---         |
+| [YuNet](./models/face_detection_yunet)                  | Face Detection                | 160x120    | 1.45           | 5.43         | 12.18           | 4.04         | 1.73               | 86.69       |
+| [SFace](./models/face_recognition_sface)                | Face Recognition              | 112x112    | 8.65           | 78.83        | 24.88           | 46.25        | 23.17              | ---         |
+| [FER](./models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 4.43           | 32.53        | 31.07           | 29.80        | 10.12              | ---         |
+| [LPD-YuNet](./models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | ---            | 167.70       | 56.12           | 29.53        | 8.70               | ---         |
+| [YOLOX](./models/object_detection_yolox/)               | Object Detection              | 640x640    | 176.68         | 1805.87      | 388.95          | 420.98       | 29.10              | ---         |
+| [NanoDet](./models/object_detection_nanodet/)           | Object Detection              | 416x416    | 157.91         | 225.10       | 64.94           | 116.64       | 35.97              | ---         |
+| [DB-IC15](./models/text_detection_db)                   | Text Detection                | 640x480    | 142.91         | 1862.75      | 208.41          | ---          | 229.74             | ---         |
+| [DB-TD500](./models/text_detection_db)                  | Text Detection                | 640x480    | 142.91         | 1878.45      | 210.51          | ---          | 247.29             | ---         |
+| [CRNN-EN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 50.21          | 278.11       | 196.15          | 125.30       | 101.03             | ---         |
+| [CRNN-CN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 73.52          | 297.48       | 239.76          | 166.79       | 136.41             | ---         |
+| [PP-ResNet](./models/image_classification_ppresnet)     | Image Classification          | 224x224    | 56.05          | 463.93       | 98.64           | 75.45        | 6.99               | ---         |
+| [MobileNet-V1](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 9.04           | 72.33        | 33.18           | 145.66\*     | 5.25               | ---         |
+| [MobileNet-V2](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 8.86           | 66.56        | 31.92           | 146.31\*     | 5.82               | ---         |
+| [PP-HumanSeg](./models/human_segmentation_pphumanseg)   | Human Segmentation            | 192x192    | 19.92          | 73.13        | 67.97           | 74.77        | 7.07               | ---         |
+| [WeChatQRCode](./models/qrcode_wechatqrcode)            | QR Code Detection and Parsing | 100x100    | 7.04           | 5.71         | ---             | ---          | ---                | ---         |
+| [DaSiamRPN](./models/object_tracking_dasiamrpn)         | Object Tracking               | 1280x720   | 36.15          | 712.94       | 76.82           | ---          | ---                | ---         |
+| [YoutuReID](./models/person_reid_youtureid)             | Person Re-Identification      | 128x256    | 35.81          | 625.56       | 90.07           | 44.61        | 5.69               | ---         |
+| [MP-PalmDet](./models/palm_detection_mediapipe)         | Palm Detection                | 192x192    | 11.09          | 86.83        | 83.20           | 33.81        | 21.59              | ---         |
+| [MP-HandPose](./models/handpose_estimation_mediapipe)   | Hand Pose Estimation          | 224x224    | 4.28           | 43.57        | 40.10           | 19.47        | 6.02               | ---         |
 
 \*: Models are quantized in per-channel mode, which run slower than per-tensor quantized models on NPU.
 
@@ -57,7 +57,7 @@ Hardware Setup:
 ***Important Notes***:
 
 - The data under each column of hardware setups on the above table represents the elapsed time of an inference (preprocess, forward and postprocess).
-- The time data is the median of 10 runs after some warmup runs. Different metrics may be applied to some specific models.
+- The time data is the mean of 10 runs after some warmup runs. Different metrics may be applied to some specific models.
 - Batch size is 1 for all benchmark results.
 - `---` represents the model is not availble to run on the device.
 - View [benchmark/config](./benchmark/config) for more details on benchmarking different models.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Guidelines:
 | [LPD-YuNet](./models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | 8.63           | 167.70       | 56.12           | 29.53        | 7.63               | ---         |
 | [YOLOX](./models/object_detection_yolox/)               | Object Detection              | 640x640    | 141.20         | 1805.87      | 388.95          | 420.98       | 28.59              | ---         |
 | [NanoDet](./models/object_detection_nanodet/)           | Object Detection              | 416x416    | 66.03          | 225.10       | 64.94           | 116.64       | 20.62              | ---         |
-| [DB-IC15](./models/text_detection_db) (EN)              | Text Detection                | 640x480    | 71.03          | 1862.75      | 208.41          | ---          | ---                | ---         |
-| [DB-TD500](./models/text_detection_db) (EN&CN)          | Text Detection                | 640x480    | 72.31          | 1878.45      | 210.51          | ---          | ---                | ---         |
+| [DB-IC15](./models/text_detection_db) (EN)              | Text Detection                | 640x480    | 71.03          | 1862.75      | 208.41          | ---          | 17.15              | ---         |
+| [DB-TD500](./models/text_detection_db) (EN&CN)          | Text Detection                | 640x480    | 72.31          | 1878.45      | 210.51          | ---          | 17.95              | ---         |
 | [CRNN-EN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 20.16          | 278.11       | 196.15          | 125.30       | ---                | ---         |
 | [CRNN-CN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 23.07          | 297.48       | 239.76          | 166.79       | ---                | ---         |
 | [PP-ResNet](./models/image_classification_ppresnet)     | Image Classification          | 224x224    | 34.71          | 463.93       | 98.64           | 75.45        | 6.99               | ---         |

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ Guidelines:
 
 Hardware Setup:
 
-- `CPU-INTEL`: [Intel Core i7-5930K](https://www.intel.com/content/www/us/en/products/sku/82931/intel-core-i75930k-processor-15m-cache-up-to-3-70-ghz/specifications.html) @ 3.50GHz, 6 cores, 12 threads.
-- `CPU-RPI`: [Raspberry Pi 4B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/), Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.5GHz.
+- `CPU-INTEL`: [Intel Core i7-12700K](https://www.intel.com/content/www/us/en/products/sku/134594/intel-core-i712700k-processor-25m-cache-up-to-5-00-ghz/specifications.html), 8 Performance-cores (3.60 GHz, turbo up to 4.90 GHz), 4 Efficient-cores (2.70 GHz, turbo up to 3.80 GHz), 20 threads.
+- `CPU-RPI`: [Raspberry Pi 4B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/), Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.5 GHz.
 - `GPU-JETSON`: [NVIDIA Jetson Nano B01](https://developer.nvidia.com/embedded/jetson-nano-developer-kit), 128-core NVIDIA Maxwell GPU.
 - `NPU-KV3`: [Khadas VIM3](https://www.khadas.com/vim3), 5TOPS Performance. Benchmarks are done using **quantized** models. You will need to compile OpenCV with TIM-VX following [this guide](https://github.com/opencv/opencv/wiki/TIM-VX-Backend-For-Running-OpenCV-On-NPU) to run benchmarks. The test results use the `per-tensor` quantization model by default.
-- `NPU-Ascend310`: [Ascend 310](https://e.huawei.com/uk/products/cloud-computing-dc/atlas/atlas-200), 22 TOPS@INT8. Benchmarks are done on [Atlas 200 DK AI Developer Kit](https://e.huawei.com/in/products/cloud-computing-dc/atlas/atlas-200). Get the latest OpenCV source code and build following [this guide](https://github.com/opencv/opencv/wiki/Huawei-CANN-Backend) to enable CANN backend.
-- `CPU-D1`: [Allwinner D1](https://d1.docs.aw-ol.com/en), [Xuantie C906 CPU](https://www.t-head.cn/product/C906?spm=a2ouz.12986968.0.0.7bfc1384auGNPZ) (RISC-V, RVV 0.7.1) @ 1.0GHz, 1 core. YuNet is supported for now. Visit [here](https://github.com/fengyuentau/opencv_zoo_cpp) for more details.
+- `NPU-Ascend310`: [Ascend 310](https://e.huawei.com/uk/products/cloud-computing-dc/atlas/atlas-200), 22 TOPS @ INT8. Benchmarks are done on [Atlas 200 DK AI Developer Kit](https://e.huawei.com/in/products/cloud-computing-dc/atlas/atlas-200). Get the latest OpenCV source code and build following [this guide](https://github.com/opencv/opencv/wiki/Huawei-CANN-Backend) to enable CANN backend.
+- `CPU-D1`: [Allwinner D1](https://d1.docs.aw-ol.com/en), [Xuantie C906 CPU](https://www.t-head.cn/product/C906?spm=a2ouz.12986968.0.0.7bfc1384auGNPZ) (RISC-V, RVV 0.7.1) @ 1.0 GHz, 1 core. YuNet is supported for now. Visit [here](https://github.com/fengyuentau/opencv_zoo_cpp) for more details.
 
 ***Important Notes***:
 

--- a/README.md
+++ b/README.md
@@ -21,38 +21,38 @@ Guidelines:
 
 ## Models & Benchmark Results
 
-| Model                                                   | Task                          | Input Size | INTEL-CPU (ms) | RPI-CPU (ms) | JETSON-GPU (ms) | KV3-NPU (ms) | Ascend-310 (ms) | D1-CPU (ms) |
-| ------------------------------------------------------- | ----------------------------- | ---------- | -------------- | ------------ | --------------- | ------------ | --------------- | ----------- |
-| [YuNet](./models/face_detection_yunet)                  | Face Detection                | 160x120    | 1.45           | 6.22         | 12.18           | 4.04         | 1.73            | 86.69       |
-| [SFace](./models/face_recognition_sface)                | Face Recognition              | 112x112    | 8.65           | 99.20        | 24.88           | 46.25        | 23.17           | ---         |
-| [FER](./models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 4.43           | 49.86        | 31.07           | 29.80        | 10.12           | ---         |
-| [LPD-YuNet](./models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | ---            | 168.03       | 56.12           | 29.53        | 8.70            | ---         |
-| [YOLOX](./models/object_detection_yolox/)               | Object Detection              | 640x640    | 176.68         | 1496.70      | 388.95          | 420.98       | 29.10           | ---         |
-| [NanoDet](./models/object_detection_nanodet/)           | Object Detection              | 416x416    | 157.91         | 220.36       | 64.94           | 116.64       | 35.97           | ---         |
-| [DB-IC15](./models/text_detection_db)                   | Text Detection                | 640x480    | 142.91         | 2835.91      | 208.41          | ---          | 229.74          | ---         |
-| [DB-TD500](./models/text_detection_db)                  | Text Detection                | 640x480    | 142.91         | 2841.71      | 210.51          | ---          | 247.29          | ---         |
-| [CRNN-EN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 50.21          | 234.32       | 196.15          | 125.30       | 101.03          | ---         |
-| [CRNN-CN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 73.52          | 322.16       | 239.76          | 166.79       | 136.41          | ---         |
-| [PP-ResNet](./models/image_classification_ppresnet)     | Image Classification          | 224x224    | 56.05          | 602.58       | 98.64           | 75.45        | 6.99            | ---         |
-| [MobileNet-V1](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 9.04           | 92.25        | 33.18           | 145.66\*     | 5.25            | ---         |
-| [MobileNet-V2](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 8.86           | 74.03        | 31.92           | 146.31\*     | 5.82            | ---         |
-| [PP-HumanSeg](./models/human_segmentation_pphumanseg)   | Human Segmentation            | 192x192    | 19.92          | 105.32       | 67.97           | 74.77        | 7.07            | ---         |
-| [WeChatQRCode](./models/qrcode_wechatqrcode)            | QR Code Detection and Parsing | 100x100    | 7.04           | 37.68        | ---             | ---          | ---             | ---         |
-| [DaSiamRPN](./models/object_tracking_dasiamrpn)         | Object Tracking               | 1280x720   | 36.15          | 705.48       | 76.82           | ---          | ---             | ---         |
-| [YoutuReID](./models/person_reid_youtureid)             | Person Re-Identification      | 128x256    | 35.81          | 521.98       | 90.07           | 44.61        | 5.69            | ---         |
-| [MP-PalmDet](./models/palm_detection_mediapipe)         | Palm Detection                | 192x192    | 11.09          | 63.79        | 83.20           | 33.81        | 21.59           | ---         |
-| [MP-HandPose](./models/handpose_estimation_mediapipe)   | Hand Pose Estimation          | 224x224    | 4.28           | 36.19        | 40.10           | 19.47        | 6.02            | ---         |
+| Model                                                   | Task                          | Input Size | CPU-INTEL (ms) | CPU-RPI (ms) | GPU-JETSON (ms) | NPU-KV3 (ms) | NPU-Ascend310 (ms) | CPU-D1 (ms) |
+| ------------------------------------------------------- | ----------------------------- | ---------- | -------------- | ------------ | --------------- | ------------ | ------------------ | ----------- |
+| [YuNet](./models/face_detection_yunet)                  | Face Detection                | 160x120    | 1.45           | 6.22         | 12.18           | 4.04         | 1.73               | 86.69       |
+| [SFace](./models/face_recognition_sface)                | Face Recognition              | 112x112    | 8.65           | 99.20        | 24.88           | 46.25        | 23.17              | ---         |
+| [FER](./models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 4.43           | 49.86        | 31.07           | 29.80        | 10.12              | ---         |
+| [LPD-YuNet](./models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | ---            | 168.03       | 56.12           | 29.53        | 8.70               | ---         |
+| [YOLOX](./models/object_detection_yolox/)               | Object Detection              | 640x640    | 176.68         | 1496.70      | 388.95          | 420.98       | 29.10              | ---         |
+| [NanoDet](./models/object_detection_nanodet/)           | Object Detection              | 416x416    | 157.91         | 220.36       | 64.94           | 116.64       | 35.97              | ---         |
+| [DB-IC15](./models/text_detection_db)                   | Text Detection                | 640x480    | 142.91         | 2835.91      | 208.41          | ---          | 229.74             | ---         |
+| [DB-TD500](./models/text_detection_db)                  | Text Detection                | 640x480    | 142.91         | 2841.71      | 210.51          | ---          | 247.29             | ---         |
+| [CRNN-EN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 50.21          | 234.32       | 196.15          | 125.30       | 101.03             | ---         |
+| [CRNN-CN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 73.52          | 322.16       | 239.76          | 166.79       | 136.41             | ---         |
+| [PP-ResNet](./models/image_classification_ppresnet)     | Image Classification          | 224x224    | 56.05          | 602.58       | 98.64           | 75.45        | 6.99               | ---         |
+| [MobileNet-V1](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 9.04           | 92.25        | 33.18           | 145.66\*     | 5.25               | ---         |
+| [MobileNet-V2](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 8.86           | 74.03        | 31.92           | 146.31\*     | 5.82               | ---         |
+| [PP-HumanSeg](./models/human_segmentation_pphumanseg)   | Human Segmentation            | 192x192    | 19.92          | 105.32       | 67.97           | 74.77        | 7.07               | ---         |
+| [WeChatQRCode](./models/qrcode_wechatqrcode)            | QR Code Detection and Parsing | 100x100    | 7.04           | 37.68        | ---             | ---          | ---                | ---         |
+| [DaSiamRPN](./models/object_tracking_dasiamrpn)         | Object Tracking               | 1280x720   | 36.15          | 705.48       | 76.82           | ---          | ---                | ---         |
+| [YoutuReID](./models/person_reid_youtureid)             | Person Re-Identification      | 128x256    | 35.81          | 521.98       | 90.07           | 44.61        | 5.69               | ---         |
+| [MP-PalmDet](./models/palm_detection_mediapipe)         | Palm Detection                | 192x192    | 11.09          | 63.79        | 83.20           | 33.81        | 21.59              | ---         |
+| [MP-HandPose](./models/handpose_estimation_mediapipe)   | Hand Pose Estimation          | 224x224    | 4.28           | 36.19        | 40.10           | 19.47        | 6.02               | ---         |
 
 \*: Models are quantized in per-channel mode, which run slower than per-tensor quantized models on NPU.
 
 Hardware Setup:
 
-- `INTEL-CPU`: [Intel Core i7-5930K](https://www.intel.com/content/www/us/en/products/sku/82931/intel-core-i75930k-processor-15m-cache-up-to-3-70-ghz/specifications.html) @ 3.50GHz, 6 cores, 12 threads.
-- `RPI-CPU`: [Raspberry Pi 4B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/), Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.5GHz.
-- `JETSON-GPU`: [NVIDIA Jetson Nano B01](https://developer.nvidia.com/embedded/jetson-nano-developer-kit), 128-core NVIDIA Maxwell GPU.
-- `KV3-NPU`: [Khadas VIM3](https://www.khadas.com/vim3), 5TOPS Performance. Benchmarks are done using **quantized** models. You will need to compile OpenCV with TIM-VX following [this guide](https://github.com/opencv/opencv/wiki/TIM-VX-Backend-For-Running-OpenCV-On-NPU) to run benchmarks. The test results use the `per-tensor` quantization model by default.
-- `Ascend-310`: [Ascend 310](https://e.huawei.com/uk/products/cloud-computing-dc/atlas/ascend-310), 22 TOPS@INT8. Benchmarks are done on [Atlas 200 DK AI Developer Kit](https://e.huawei.com/in/products/cloud-computing-dc/atlas/atlas-200). Get the latest OpenCV source code and build following [this guide](https://github.com/opencv/opencv/wiki/Huawei-CANN-Backend) to enable CANN backend.
-- `D1-CPU`: [Allwinner D1](https://d1.docs.aw-ol.com/en), [Xuantie C906 CPU](https://www.t-head.cn/product/C906?spm=a2ouz.12986968.0.0.7bfc1384auGNPZ) (RISC-V, RVV 0.7.1) @ 1.0GHz, 1 core. YuNet is supported for now. Visit [here](https://github.com/fengyuentau/opencv_zoo_cpp) for more details.
+- `CPU-INTEL`: [Intel Core i7-5930K](https://www.intel.com/content/www/us/en/products/sku/82931/intel-core-i75930k-processor-15m-cache-up-to-3-70-ghz/specifications.html) @ 3.50GHz, 6 cores, 12 threads.
+- `CPU-RPI`: [Raspberry Pi 4B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/), Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.5GHz.
+- `GPU-JETSON`: [NVIDIA Jetson Nano B01](https://developer.nvidia.com/embedded/jetson-nano-developer-kit), 128-core NVIDIA Maxwell GPU.
+- `NPU-KV3`: [Khadas VIM3](https://www.khadas.com/vim3), 5TOPS Performance. Benchmarks are done using **quantized** models. You will need to compile OpenCV with TIM-VX following [this guide](https://github.com/opencv/opencv/wiki/TIM-VX-Backend-For-Running-OpenCV-On-NPU) to run benchmarks. The test results use the `per-tensor` quantization model by default.
+- `NPU-Ascend310`: [Ascend 310](https://e.huawei.com/uk/products/cloud-computing-dc/atlas/ascend-310), 22 TOPS@INT8. Benchmarks are done on [Atlas 200 DK AI Developer Kit](https://e.huawei.com/in/products/cloud-computing-dc/atlas/atlas-200). Get the latest OpenCV source code and build following [this guide](https://github.com/opencv/opencv/wiki/Huawei-CANN-Backend) to enable CANN backend.
+- `CPU-D1`: [Allwinner D1](https://d1.docs.aw-ol.com/en), [Xuantie C906 CPU](https://www.t-head.cn/product/C906?spm=a2ouz.12986968.0.0.7bfc1384auGNPZ) (RISC-V, RVV 0.7.1) @ 1.0GHz, 1 core. YuNet is supported for now. Visit [here](https://github.com/fengyuentau/opencv_zoo_cpp) for more details.
 
 ***Important Notes***:
 

--- a/README.md
+++ b/README.md
@@ -23,25 +23,25 @@ Guidelines:
 
 | Model                                                   | Task                          | Input Size | CPU-INTEL (ms) | CPU-RPI (ms) | GPU-JETSON (ms) | NPU-KV3 (ms) | NPU-Ascend310 (ms) | CPU-D1 (ms) |
 | ------------------------------------------------------- | ----------------------------- | ---------- | -------------- | ------------ | --------------- | ------------ | ------------------ | ----------- |
-| [YuNet](./models/face_detection_yunet)                  | Face Detection                | 160x120    | 0.72           | 5.43         | 12.18           | 4.04         | 1.73               | 86.69       |
-| [SFace](./models/face_recognition_sface)                | Face Recognition              | 112x112    | 6.04           | 78.83        | 24.88           | 46.25        | 23.17              | ---         |
-| [FER](./models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 3.16           | 32.53        | 31.07           | 29.80        | 10.12              | ---         |
-| [LPD-YuNet](./models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | 8.63           | 167.70       | 56.12           | 29.53        | 8.70               | ---         |
-| [YOLOX](./models/object_detection_yolox/)               | Object Detection              | 640x640    | 141.20         | 1805.87      | 388.95          | 420.98       | 29.10              | ---         |
-| [NanoDet](./models/object_detection_nanodet/)           | Object Detection              | 416x416    | 66.03          | 225.10       | 64.94           | 116.64       | 35.97              | ---         |
-| [DB-IC15](./models/text_detection_db) (EN)              | Text Detection                | 640x480    | 71.03          | 1862.75      | 208.41          | ---          | 229.74             | ---         |
-| [DB-TD500](./models/text_detection_db) (EN&CN)          | Text Detection                | 640x480    | 72.31          | 1878.45      | 210.51          | ---          | 247.29             | ---         |
-| [CRNN-EN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 20.16          | 278.11       | 196.15          | 125.30       | 101.03             | ---         |
-| [CRNN-CN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 23.07          | 297.48       | 239.76          | 166.79       | 136.41             | ---         |
+| [YuNet](./models/face_detection_yunet)                  | Face Detection                | 160x120    | 0.72           | 5.43         | 12.18           | 4.04         | 2.24               | 86.69       |
+| [SFace](./models/face_recognition_sface)                | Face Recognition              | 112x112    | 6.04           | 78.83        | 24.88           | 46.25        | 2.66               | ---         |
+| [FER](./models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 3.16           | 32.53        | 31.07           | 29.80        | 2.19               | ---         |
+| [LPD-YuNet](./models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | 8.63           | 167.70       | 56.12           | 29.53        | 7.63               | ---         |
+| [YOLOX](./models/object_detection_yolox/)               | Object Detection              | 640x640    | 141.20         | 1805.87      | 388.95          | 420.98       | 28.59              | ---         |
+| [NanoDet](./models/object_detection_nanodet/)           | Object Detection              | 416x416    | 66.03          | 225.10       | 64.94           | 116.64       | 20.62              | ---         |
+| [DB-IC15](./models/text_detection_db) (EN)              | Text Detection                | 640x480    | 71.03          | 1862.75      | 208.41          | ---          | ---                | ---         |
+| [DB-TD500](./models/text_detection_db) (EN&CN)          | Text Detection                | 640x480    | 72.31          | 1878.45      | 210.51          | ---          | ---                | ---         |
+| [CRNN-EN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 20.16          | 278.11       | 196.15          | 125.30       | ---                | ---         |
+| [CRNN-CN](./models/text_recognition_crnn)               | Text Recognition              | 100x32     | 23.07          | 297.48       | 239.76          | 166.79       | ---                | ---         |
 | [PP-ResNet](./models/image_classification_ppresnet)     | Image Classification          | 224x224    | 34.71          | 463.93       | 98.64           | 75.45        | 6.99               | ---         |
-| [MobileNet-V1](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 5.90           | 72.33        | 33.18           | 145.66\*     | 5.25               | ---         |
-| [MobileNet-V2](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 5.97           | 66.56        | 31.92           | 146.31\*     | 5.82               | ---         |
-| [PP-HumanSeg](./models/human_segmentation_pphumanseg)   | Human Segmentation            | 192x192    | 8.81           | 73.13        | 67.97           | 74.77        | 7.07               | ---         |
+| [MobileNet-V1](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 5.90           | 72.33        | 33.18           | 145.66\*     | 5.15               | ---         |
+| [MobileNet-V2](./models/image_classification_mobilenet) | Image Classification          | 224x224    | 5.97           | 66.56        | 31.92           | 146.31\*     | 5.41               | ---         |
+| [PP-HumanSeg](./models/human_segmentation_pphumanseg)   | Human Segmentation            | 192x192    | 8.81           | 73.13        | 67.97           | 74.77        | 6.94               | ---         |
 | [WeChatQRCode](./models/qrcode_wechatqrcode)            | QR Code Detection and Parsing | 100x100    | 1.29           | 5.71         | ---             | ---          | ---                | ---         |
 | [DaSiamRPN](./models/object_tracking_dasiamrpn)         | Object Tracking               | 1280x720   | 29.05          | 712.94       | 76.82           | ---          | ---                | ---         |
-| [YoutuReID](./models/person_reid_youtureid)             | Person Re-Identification      | 128x256    | 30.39          | 625.56       | 90.07           | 44.61        | 5.69               | ---         |
-| [MP-PalmDet](./models/palm_detection_mediapipe)         | Palm Detection                | 192x192    | 6.29           | 86.83        | 83.20           | 33.81        | 21.59              | ---         |
-| [MP-HandPose](./models/handpose_estimation_mediapipe)   | Hand Pose Estimation          | 224x224    | 4.68           | 43.57        | 40.10           | 19.47        | 6.02               | ---         |
+| [YoutuReID](./models/person_reid_youtureid)             | Person Re-Identification      | 128x256    | 30.39          | 625.56       | 90.07           | 44.61        | 5.58               | ---         |
+| [MP-PalmDet](./models/palm_detection_mediapipe)         | Palm Detection                | 192x192    | 6.29           | 86.83        | 83.20           | 33.81        | 5.17               | ---         |
+| [MP-HandPose](./models/handpose_estimation_mediapipe)   | Hand Pose Estimation          | 224x224    | 4.68           | 43.57        | 40.10           | 19.47        | 6.27               | ---         |
 
 \*: Models are quantized in per-channel mode, which run slower than per-tensor quantized models on NPU.
 
@@ -51,7 +51,7 @@ Hardware Setup:
 - `CPU-RPI`: [Raspberry Pi 4B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/), Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.5GHz.
 - `GPU-JETSON`: [NVIDIA Jetson Nano B01](https://developer.nvidia.com/embedded/jetson-nano-developer-kit), 128-core NVIDIA Maxwell GPU.
 - `NPU-KV3`: [Khadas VIM3](https://www.khadas.com/vim3), 5TOPS Performance. Benchmarks are done using **quantized** models. You will need to compile OpenCV with TIM-VX following [this guide](https://github.com/opencv/opencv/wiki/TIM-VX-Backend-For-Running-OpenCV-On-NPU) to run benchmarks. The test results use the `per-tensor` quantization model by default.
-- `NPU-Ascend310`: [Ascend 310](https://e.huawei.com/uk/products/cloud-computing-dc/atlas/ascend-310), 22 TOPS@INT8. Benchmarks are done on [Atlas 200 DK AI Developer Kit](https://e.huawei.com/in/products/cloud-computing-dc/atlas/atlas-200). Get the latest OpenCV source code and build following [this guide](https://github.com/opencv/opencv/wiki/Huawei-CANN-Backend) to enable CANN backend.
+- `NPU-Ascend310`: [Ascend 310](https://e.huawei.com/uk/products/cloud-computing-dc/atlas/atlas-200), 22 TOPS@INT8. Benchmarks are done on [Atlas 200 DK AI Developer Kit](https://e.huawei.com/in/products/cloud-computing-dc/atlas/atlas-200). Get the latest OpenCV source code and build following [this guide](https://github.com/opencv/opencv/wiki/Huawei-CANN-Backend) to enable CANN backend.
 - `CPU-D1`: [Allwinner D1](https://d1.docs.aw-ol.com/en), [Xuantie C906 CPU](https://www.t-head.cn/product/C906?spm=a2ouz.12986968.0.0.7bfc1384auGNPZ) (RISC-V, RVV 0.7.1) @ 1.0GHz, 1 core. YuNet is supported for now. Visit [here](https://github.com/fengyuentau/opencv_zoo_cpp) for more details.
 
 ***Important Notes***:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -345,7 +345,7 @@ Specs: [details_en](https://e.huawei.com/uk/products/cloud-computing-dc/atlas/at
 CPU:
 
 ```
-$ python3 benchmark.py --all --cfg_exclude wechat:dasiamrpn --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+$ python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
 Benchmarking ...
 backend=cv.dnn.DNN_BACKEND_OPENCV
 target=cv.dnn.DNN_TARGET_CPU
@@ -370,6 +370,7 @@ mean       median     min        input size   model
 351.64     346.41     315.99     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
 1995.97    1996.82    1967.76    [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
 2060.87    2055.60    1967.76    [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+701.08     708.52     685.49     [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
 105.23     105.14     105.00     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
 123.41     125.65     105.00     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
 631.70     631.81     630.61     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
@@ -390,14 +391,33 @@ mean       median     min        input size   model
 NPU:
 
 ```
-$ 
+$ python3 benchmark.py --all --fp32 --cfg_exclude wechat:dasiamrpn:db:crnn --cfg_overwrite_backend_target 4
+Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_CANN
+target=cv.dnn.DNN_TARGET_NPU
+mean       median     min        input size   model
+2.24       2.21       2.19       [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+2.66       2.66       2.64       [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+2.19       2.19       2.16       [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+6.27       6.22       6.17       [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+6.94       6.94       6.85       [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+5.15       5.13       5.10       [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+5.41       5.42       5.10       [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+6.99       6.99       6.95       [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+7.63       7.64       7.43       [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+20.62      22.09      19.16      [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+28.59      28.60      27.91      [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+5.17       5.26       5.09       [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+5.58       5.57       5.54       [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
 ```
 
 ### Khadas Edge2 (RK3588)
 
 Specs: [details](https://www.khadas.com/edge2)
 - (SoC) CPU: 2.25GHz Quad Core ARM Cortex-A76 + 1.8GHz Quad Core Cortex-A55
+<!--
 - (SoC) NPU: 6 TOPS INT8
+-->
 
 CPU:
 
@@ -445,13 +465,120 @@ mean       median     min        input size   model
 73.91      74.25      63.98      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```
 
-### Toybrick RV1126
+### Horizon Sunrise X3 PI
 
-Specs: 
-- CPU: 
+Specs: [details_cn](https://developer.horizon.ai/sunrise)
+- CPU: ARM Cortex-A53，4xCore, 1.2G
+- BPU (aka NPU): (Bernoulli Arch) 2×Core，up to 1.0G, ~5Tops
+
+```
+$ python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_OPENCV
+target=cv.dnn.DNN_TARGET_CPU
+mean       median     min        input size   model
+11.04      11.01      10.98      [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+12.59      12.75      10.98      [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+140.83     140.85     140.52     [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+171.71     175.65     140.52     [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
+64.96      64.94      64.77      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+80.20      81.82      64.77      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+80.67      80.72      80.45      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+89.25      90.39      80.45      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+144.23     144.34     143.84     [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+140.60     140.62     140.33     [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+122.53     124.23     107.71     [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+128.22     107.87     107.71     [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+125.77     123.77     107.71     [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+759.81     760.01     759.11     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+764.17     764.43     759.11     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+283.75     284.17     282.15     [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+408.16     408.31     402.71     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+408.82     407.99     402.71     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+2749.22    2756.23    2737.96    [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+2671.54    2692.18    2601.24    [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+929.63     936.01     914.86     [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+142.23     142.03     141.78     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+179.74     184.79     141.78     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+898.23     897.52     896.58     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+749.83     765.90     630.39     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+1908.87    1905.00    1903.13    [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+1922.34    1920.65    1896.97    [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+470.78     469.17     467.92     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+495.94     497.12     467.92     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+464.58     528.72     408.69     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@2820.735] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+465.04     467.01     408.69     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+452.90     409.34     408.69     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+450.23     438.57     408.69     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+453.52     468.72     408.69     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+443.38     447.29     381.90     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+```
+
+
+### MAIX-III AX-PI
+
+Specs: [details_en](https://wiki.sipeed.com/hardware/en/maixIII/ax-pi/axpi.html#Hardware), [details_cn](https://wiki.sipeed.com/hardware/zh/maixIII/ax-pi/axpi.html#%E7%A1%AC%E4%BB%B6%E5%8F%82%E6%95%B0)
+- CPU: Quad cores ARM Cortex-A7
+<!--
+- NPU: 14.4Tops@int4，3.6Tops@int8
+-->
 
 CPU:
 
 ```
-$ 
+```
+
+### Toybrick RV1126
+
+Specs: [details](https://t.rock-chips.com/en/portal.php?mod=view&aid=26)
+- CPU: Quard core ARM Cortex-A7, up to 1.5GHz
+<!--
+- NPU: 2.0TOPS INT8 (not supported by OpenCV DNN)
+-->
+
+CPU:
+
+```
+$ python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_OPENCV
+target=cv.dnn.DNN_TARGET_CPU
+mean       median     min        input size   model
+68.89      68.59      68.23      [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+60.98      61.11      52.00      [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+1550.71    1578.99    1527.58    [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+1214.15    1261.66    920.50     [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
+604.36     611.24     578.99     [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+496.42     537.75     397.23     [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+460.56     470.15     440.77     [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+387.63     379.96     318.71     [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+1610.78    1599.92    1583.95    [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+1546.16    1539.50    1513.14    [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+1166.56    1211.97    827.10     [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+983.80     868.18     689.32     [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+840.38     801.83     504.54     [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+11793.09   11817.73   11741.04   [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+7740.03    8134.99    4464.30    [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+3222.92    3225.18    3170.71    [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+2303.55    2307.46    2289.41    [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+1888.15    1920.41    1528.78    [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+38359.93   39021.21   37180.85   [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+24504.50   25439.34   13443.63   [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+14738.64   14764.84   14655.76   [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+872.09     877.72     838.99     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+764.48     775.55     653.25     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+11117.07   11109.12   11058.49   [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+7037.96    7424.89    3750.12    [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+49065.03   49144.55   48943.50   [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+49052.24   48992.64   48927.44   [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+2200.08    2193.78    2175.77    [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+2244.03    2240.25    2175.77    [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+2230.12    2290.28    2175.77    [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@1315.065] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+2220.33    2281.75    2171.61    [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+2216.44    2212.48    2171.61    [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+2041.65    2209.50    1268.91    [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+1933.06    2210.81    1268.91    [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+1826.34    2234.66    1184.53    [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -40,3 +40,51 @@ Omit `--cfg` if you want to benchmark all included models:
 PYTHONPATH=.. python benchmark.py
 ```
 -->
+
+## More Results
+
+Benchmark is done with latest `opencv-python==4.7.0.72` and `opencv-contrib-python==4.7.0.72` on the following platforms. Some models are excluded because of support issues.
+
+### Rasberry Pi 4B (CPU)
+
+```
+$ python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar-act_int8-wt_int8-quantized.onnx:human_segmentation_pphumanseg_2023mar-act_int8-wt_int8-quantized.onnx
+Benchmarking ...
+mean=5.43	median=5.41	min=5.38	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
+mean=6.09	median=6.19	min=5.38	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar-act_int8-wt_int8-quantized.onnx']
+mean=78.83	median=78.83	min=78.43	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
+mean=92.56	median=94.20	min=78.43	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec-act_int8-wt_int8-quantized.onnx']
+mean=32.53	median=32.51	min=32.33	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+mean=38.61	median=39.19	min=32.33	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july-int8-quantized.onnx']
+mean=43.57	median=43.59	min=43.26	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+mean=46.69	median=47.12	min=43.26	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb-act_int8-wt_int8-quantized.onnx']
+mean=73.13	median=73.79	min=72.71	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+mean=72.33	median=72.49	min=72.13	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+mean=66.56	median=66.92	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+mean=67.47	median=62.02	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr-int8-quantized.onnx']
+mean=66.01	median=65.53	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr-int8-quantized.onnx']
+mean=463.93	median=463.23	min=459.88	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+mean=441.38	median=434.24	min=373.27	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan-act_int8-wt_int8-quantized.onnx']
+mean=167.70	median=173.37	min=143.13	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+mean=225.10	median=223.10	min=208.92	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
+mean=226.14	median=226.32	min=206.70	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+mean=1805.87	median=1827.43	min=1717.68	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
+mean=1737.66	median=1789.99	min=1575.72	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+mean=712.94	median=701.07	min=580.18	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+mean=86.83	median=76.78	min=65.25	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+mean=107.26	median=98.07	min=65.25	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb-act_int8-wt_int8-quantized.onnx']
+mean=625.56	median=622.26	min=599.92	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
+mean=512.76	median=519.71	min=353.70	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov-act_int8-wt_int8-quantized.onnx']
+mean=5.71	median=5.76	min=5.63	input size=[100, 100]	model: WeChatQRCode with ['detect_2021nov.prototxt', 'detect_2021nov.caffemodel', 'sr_2021nov.prototxt', 'sr_2021nov.caffemodel']
+mean=1862.75	median=1849.26	min=1812.02	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+mean=1878.45	median=1880.35	min=1812.02	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+mean=271.85	median=276.14	min=259.73	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+mean=297.48	median=300.89	min=259.73	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+mean=278.11	median=357.83	min=229.71	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@1933.986] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+mean=272.00	median=289.96	min=229.71	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+mean=261.77	median=273.49	min=228.71	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+mean=254.22	median=253.40	min=226.83	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+mean=251.15	median=260.79	min=226.83	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov-act_int8-wt_int8-quantized.onnx']
+mean=242.05	median=245.09	min=190.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -47,54 +47,61 @@ Benchmark is done with latest `opencv-python==4.7.0.72` and `opencv-contrib-pyth
 
 ### Intel 12700K
 
-CPU:
+Specs: [details](https://www.intel.com/content/www/us/en/products/sku/82931/intel-core-i75930k-processor-15m-cache-up-to-3-70-ghz/specifications.html)
+- CPU: 3.50GHz, 6 cores, 12 threads.
+
+CPU: 
 
 ```
 $ python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
 Benchmarking ...
 backend=cv.dnn.DNN_BACKEND_OPENCV
 target=cv.dnn.DNN_TARGET_CPU
-mean=0.72	median=0.70	min=0.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
-mean=0.90	median=0.90	min=0.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
-mean=6.04	median=6.08	min=5.59	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
-mean=7.34	median=7.94	min=5.59	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
-mean=3.16	median=3.37	min=2.87	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-mean=4.14	median=3.98	min=2.87	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
-mean=4.68	median=4.59	min=4.13	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-mean=4.90	median=4.71	min=4.13	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
-mean=8.81	median=7.37	min=6.53	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
-mean=5.90	median=5.87	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
-mean=5.97	median=6.66	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-mean=6.34	median=6.01	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
-mean=6.52	median=7.02	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
-mean=34.71	median=35.41	min=32.15	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-mean=35.03	median=35.31	min=32.15	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
-mean=8.63	median=7.99	min=7.54	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
-mean=66.03	median=64.57	min=61.72	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
-mean=65.78	median=68.48	min=61.72	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
-mean=141.20	median=151.61	min=118.97	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
-mean=141.85	median=151.42	min=118.97	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
-mean=29.05	median=28.50	min=22.84	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
-mean=6.29	median=6.27	min=5.90	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-mean=8.65	median=9.08	min=5.90	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
-mean=30.39	median=29.95	min=29.43	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
-mean=30.71	median=30.73	min=29.43	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
-mean=1.29	median=1.23	min=1.12	input size=[100, 100]	model: WeChatQRCode with ['detect_2021nov.prototxt', 'detect_2021nov.caffemodel', 'sr_2021nov.prototxt', 'sr_2021nov.caffemodel']
-mean=71.03	median=70.79	min=64.87	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
-mean=72.31	median=76.96	min=64.87	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
-mean=21.33	median=25.27	min=16.34	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
-mean=23.07	median=22.38	min=16.34	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
-mean=20.16	median=26.50	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
-[ WARN:0@144.899] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
-mean=20.58	median=24.46	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
-mean=19.28	median=16.05	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
-mean=19.27	median=16.80	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
-mean=19.55	median=17.81	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
-mean=18.94	median=21.04	min=11.09	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+mean       median     min        input size   model
+0.58       0.67       0.48       [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+0.82       0.81       0.48       [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+6.18       6.33       5.83       [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+7.42       7.42       5.83       [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
+3.32       3.46       2.76       [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+4.27       4.22       2.76       [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+4.68       5.04       4.36       [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+4.82       4.98       4.36       [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+8.20       9.33       6.66       [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+6.25       7.02       5.49       [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+6.00       6.31       5.49       [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+6.23       5.64       5.49       [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+6.50       6.87       5.49       [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+35.40      36.58      33.63      [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+35.79      35.53      33.48      [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+8.53       8.59       7.55       [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+65.15      77.44      45.40      [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+58.82      69.99      45.26      [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+137.53     136.70     119.95     [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+139.60     147.79     119.95     [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+29.46      42.21      25.82      [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+6.14       6.02       5.91       [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+8.51       9.89       5.91       [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+30.87      30.69      29.85      [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+30.77      30.02      27.97      [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+1.35       1.37       1.30       [100, 100]   WeChatQRCode with ['detect_2021nov.prototxt', 'detect_2021nov.caffemodel', 'sr_2021nov.prototxt', 'sr_2021nov.caffemodel']
+75.82      75.37      69.18      [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+74.80      75.16      69.05      [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+21.37      24.50      16.04      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+23.08      25.14      16.04      [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+20.43      31.14      11.74      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@145.253] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+20.71      17.95      11.74      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+19.48      25.14      11.74      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+19.38      18.85      11.74      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+19.52      25.97      11.74      [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+18.55      15.29      10.35      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```
 
 ### Rasberry Pi 4B
 
+Specs: [details](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/)
+- CPU: Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.5GHz.
+
 CPU:
 
 ```
@@ -102,90 +109,97 @@ $ python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_20
 Benchmarking ...
 backend=cv.dnn.DNN_BACKEND_OPENCV
 target=cv.dnn.DNN_TARGET_CPU
-mean=5.43	median=5.41	min=5.38	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
-mean=6.09	median=6.19	min=5.38	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
-mean=78.83	median=78.83	min=78.43	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
-mean=92.56	median=94.20	min=78.43	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
-mean=32.53	median=32.51	min=32.33	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-mean=38.61	median=39.19	min=32.33	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
-mean=43.57	median=43.59	min=43.26	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-mean=46.69	median=47.12	min=43.26	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
-mean=73.13	median=73.79	min=72.71	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
-mean=72.33	median=72.49	min=72.13	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
-mean=66.56	median=66.92	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-mean=67.47	median=62.02	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
-mean=66.01	median=65.53	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
-mean=463.93	median=463.23	min=459.88	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-mean=441.38	median=434.24	min=373.27	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
-mean=167.70	median=173.37	min=143.13	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
-mean=225.10	median=223.10	min=208.92	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
-mean=226.14	median=226.32	min=206.70	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
-mean=1805.87	median=1827.43	min=1717.68	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
-mean=1737.66	median=1789.99	min=1575.72	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
-mean=712.94	median=701.07	min=580.18	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
-mean=86.83	median=76.78	min=65.25	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-mean=107.26	median=98.07	min=65.25	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
-mean=625.56	median=622.26	min=599.92	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
-mean=512.76	median=519.71	min=353.70	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
-mean=5.71	median=5.76	min=5.63	input size=[100, 100]	model: WeChatQRCode with ['detect_2021nov.prototxt', 'detect_2021nov.caffemodel', 'sr_2021nov.prototxt', 'sr_2021nov.caffemodel']
-mean=1862.75	median=1849.26	min=1812.02	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
-mean=1878.45	median=1880.35	min=1812.02	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
-mean=271.85	median=276.14	min=259.73	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
-mean=297.48	median=300.89	min=259.73	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
-mean=278.11	median=357.83	min=229.71	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
-[ WARN:0@1933.986] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
-mean=272.00	median=289.96	min=229.71	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
-mean=261.77	median=273.49	min=228.71	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
-mean=254.22	median=253.40	min=226.83	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
-mean=251.15	median=260.79	min=226.83	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
-mean=242.05	median=245.09	min=190.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+mean       median     min        input size   model
+5.45       5.44       5.39       [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+6.12       6.15       5.39       [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+78.04      77.96      77.62      [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+91.44      93.03      77.62      [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
+32.21      31.86      31.85      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+38.22      39.27      31.85      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+43.85      43.76      43.51      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+46.66      47.00      43.51      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+73.29      73.70      72.86      [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+74.51      87.71      73.83      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+67.29      68.22      61.55      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+68.53      61.77      61.55      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+68.31      72.16      61.55      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+547.70     547.68     494.91     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+527.14     567.06     465.02     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+192.61     194.08     156.62     [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+248.03     229.41     209.65     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+246.41     247.64     207.91     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+1932.97    1941.47    1859.96    [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+1866.98    1866.50    1746.67    [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+762.56     738.04     654.25     [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+91.48      91.28      91.15      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+115.58     135.17     91.15      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+676.15     655.20     636.06     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+548.93     582.29     443.32     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+8.18       8.15       8.13       [100, 100]   WeChatQRCode with ['detect_2021nov.prototxt', 'detect_2021nov.caffemodel', 'sr_2021nov.prototxt', 'sr_2021nov.caffemodel']
+2025.09    2046.92    1971.57    [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+2041.85    2048.24    1971.57    [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+272.81     285.66     259.93     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+293.83     289.93     259.93     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+271.57     317.17     223.36     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@2039.612] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+266.67     269.64     223.36     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+259.06     239.43     223.36     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+251.39     257.43     221.20     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+248.27     253.01     221.20     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+239.42     238.72     190.04     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```
 
 ### Jetson Nano B01
 
+Specs: [details](https://developer.nvidia.com/embedded/jetson-nano-developer-kit)
+- CPU: Quad-core ARM A57 @ 1.43 GHz
+- GPU: 128-core NVIDIA Maxwell
+
 CPU:
 
 ```
-$ python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+$ python3 benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
 Benchmarking ...
 backend=cv.dnn.DNN_BACKEND_OPENCV
 target=cv.dnn.DNN_TARGET_CPU
-mean=5.29	median=5.29	min=5.23	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
-mean=6.03	median=6.18	min=5.23	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
-mean=65.42	median=65.37	min=65.20	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
-mean=79.12	median=79.78	min=65.20	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
-mean=28.28	median=28.30	min=28.12	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-mean=34.87	median=35.71	min=28.12	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
-mean=40.87	median=40.84	min=40.71	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-mean=44.14	median=44.28	min=40.71	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
-mean=65.94	median=65.86	min=65.72	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
-mean=69.17	median=69.04	min=68.84	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
-mean=62.20	median=62.36	min=55.52	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-mean=66.22	median=55.93	min=55.52	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
-mean=65.34	median=75.35	min=55.52	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
-mean=374.52	median=383.78	min=367.81	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-mean=389.18	median=408.69	min=367.81	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
-mean=130.63	median=131.11	min=128.36	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
-mean=214.30	median=212.83	min=212.53	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
-mean=216.49	median=220.40	min=212.53	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
-mean=1225.13	median=1234.78	min=1213.85	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
-mean=1256.33	median=1261.81	min=1213.85	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
-mean=471.54	median=492.74	min=450.43	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
-mean=70.52	median=70.05	min=69.65	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-mean=82.59	median=82.46	min=69.65	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
-mean=420.32	median=414.19	min=410.95	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
-mean=375.09	median=384.11	min=333.25	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
-mean=1106.86	median=1093.50	min=1090.64	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
-mean=1104.27	median=1106.12	min=1086.68	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
-mean=281.11	median=296.92	min=276.23	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
-mean=297.92	median=302.00	min=276.23	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
-mean=277.85	median=313.29	min=240.38	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
-[ WARN:0@1524.821] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
-mean=275.41	median=299.86	min=240.38	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
-mean=265.87	median=241.65	min=230.57	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
-mean=264.09	median=255.31	min=230.57	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
-mean=264.84	median=276.17	min=230.57	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
-mean=259.24	median=249.23	min=224.99	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+mean       median     min        input size   model
+5.37       5.44       5.27       [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+6.11       7.99       5.27       [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+65.14      65.13      64.93      [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+79.33      88.12      64.93      [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
+28.19      28.17      28.05      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+34.85      35.66      28.05      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+41.02      42.37      40.80      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+44.20      44.39      40.80      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+65.91      65.93      65.68      [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+68.94      68.95      68.77      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+62.12      62.24      55.29      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+66.04      55.58      55.29      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+65.31      64.86      55.29      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+376.88     368.22     367.11     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+390.32     385.28     367.11     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+133.15     130.57     129.38     [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+215.57     225.11     212.66     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+217.37     214.85     212.66     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+1228.13    1233.90    1219.11    [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+1257.34    1256.26    1219.11    [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+466.19     457.89     442.88     [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+69.60      69.69      69.13      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+81.65      82.20      69.13      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+411.49     417.53     402.57     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+372.94     370.17     335.95     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+5.62       5.64       5.55       [100, 100]   WeChatQRCode with ['detect_2021nov.prototxt', 'detect_2021nov.caffemodel', 'sr_2021nov.prototxt', 'sr_2021nov.caffemodel']
+1089.89    1091.85    1071.95    [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+1089.94    1095.07    1071.95    [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+274.45     286.03     270.52     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+290.82     288.87     270.52     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+269.52     311.59     228.47     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@1497.159] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+269.66     267.98     228.47     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+261.39     231.92     228.47     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+259.68     249.43     228.47     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+260.89     283.44     228.47     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+255.61     249.41     222.38     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```
 
 GPU (CUDA-FP32):
@@ -194,25 +208,26 @@ $ python3 benchmark.py --all --fp32 --cfg_exclude wechat --cfg_overwrite_backend
 Benchmarking ...
 backend=cv.dnn.DNN_BACKEND_CUDA
 target=cv.dnn.DNN_TARGET_CUDA
-mean=11.88	median=11.42	min=9.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
-mean=24.64	median=24.45	min=24.25	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
-mean=20.56	median=21.16	min=18.78	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-mean=41.09	median=46.72	min=40.55	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-mean=89.74	median=86.81	min=84.49	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
-mean=69.14	median=80.06	min=68.81	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
-mean=62.03	median=62.19	min=55.37	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-mean=146.98	median=148.92	min=144.63	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-mean=53.37	median=54.02	min=51.89	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
-mean=213.78	median=214.45	min=212.26	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
-mean=1233.68	median=1244.26	min=1223.56	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
-mean=76.43	median=75.60	min=74.54	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
-mean=61.60	median=65.97	min=58.57	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-mean=127.71	median=127.58	min=125.22	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
-mean=303.00	median=303.69	min=297.90	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
-mean=301.84	median=299.22	min=297.08	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
-mean=57.34	median=53.10	min=51.87	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
-mean=58.70	median=63.59	min=51.87	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
-mean=45.11	median=57.01	min=21.63	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+mean       median     min        input size   model
+11.22      11.49      9.59       [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+24.60      25.91      24.16      [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+20.64      24.00      18.88      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+41.15      41.18      40.95      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+90.86      90.79      84.96      [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+69.24      69.11      68.87      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+62.12      62.30      55.28      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+148.58     153.17     144.61     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+53.50      54.29      51.48      [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+214.99     218.04     212.94     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+1238.91    1244.87    1227.30    [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+76.54      76.09      74.51      [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+67.34      67.83      62.38      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+126.65     126.63     124.96     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+303.12     302.80     299.30     [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+302.58     299.78     297.83     [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+58.05      62.90      52.47      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+59.39      56.82      52.47      [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+45.60      62.40      21.73      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
 ```
 
 GPU (CUDA-FP16):
@@ -222,97 +237,221 @@ $ python3 benchmark.py --all --fp32 --cfg_exclude wechat --cfg_overwrite_backend
 Benchmarking ...
 backend=cv.dnn.DNN_BACKEND_CUDA
 target=cv.dnn.DNN_TARGET_CUDA_FP16
-mean=26.34	median=25.66	min=25.55	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
-mean=111.40	median=111.36	min=110.84	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
-mean=115.56	median=113.08	min=112.66	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-mean=40.77	median=40.71	min=40.55	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-mean=98.94	median=97.82	min=91.00	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
-mean=68.83	median=68.54	min=68.40	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
-mean=61.39	median=61.97	min=55.02	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-mean=136.91	median=129.33	min=128.82	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-mean=363.36	median=364.91	min=358.08	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
-mean=215.61	median=225.95	min=212.47	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
-mean=1221.35	median=1230.06	min=1209.94	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
-mean=52.16	median=52.17	min=50.31	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
-mean=213.30	median=218.13	min=208.08	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-mean=92.16	median=89.69	min=87.86	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
-mean=345.59	median=345.03	min=340.60	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
-mean=345.38	median=352.14	min=337.76	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
-mean=49.97	median=49.72	min=45.73	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
-mean=50.40	median=51.25	min=45.73	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
-mean=39.68	median=55.06	min=20.87	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+mean       median     min        input size   model
+26.17      26.40      25.87      [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+116.07     115.93     112.39     [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+119.85     121.62     114.63     [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+40.94      40.92      40.70      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+99.88      100.49     93.24      [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+69.00      68.81      68.60      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+61.93      62.18      55.17      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+141.11     145.82     136.02     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+364.70     363.48     360.28     [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+215.23     213.49     213.06     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+1223.32    1248.88    1213.25    [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+52.91      52.96      50.17      [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+212.86     213.21     210.03     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+96.68      94.21      89.24      [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+343.38     344.17     337.62     [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+344.29     345.07     337.62     [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+48.91      50.31      45.41      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+50.20      49.66      45.41      [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+39.56      52.56      20.76      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
 ```
 
 ### Khadas VIM3
 
+Specs: [details](https://www.khadas.com/vim3)
+- (SoC) CPU: Amlogic A311D, 2.2GHz Quad core ARM Cortex-A73 and 1.8GHz dual core Cortex-A53
+- NPU: 5 TOPS Performance NPU INT8 inference up to 1536 MAC Supports all major deep learning frameworks including TensorFlow and Caffe 
+
 CPU:
 
 ```
-$ python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+$ python3 benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
 Benchmarking ...
 backend=cv.dnn.DNN_BACKEND_OPENCV
 target=cv.dnn.DNN_TARGET_CPU
-mean=4.88	median=4.95	min=4.78	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
-mean=5.28	median=5.36	min=4.78	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
-mean=61.12	median=61.16	min=58.08	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
-mean=70.74	median=70.32	min=58.08	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
-mean=29.07	median=37.91	min=28.24	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-mean=34.33	median=33.97	min=28.24	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
-mean=38.71	median=38.17	min=37.07	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-mean=41.70	median=42.95	min=37.07	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
-mean=70.71	median=70.68	min=66.49	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
-mean=67.46	median=65.78	min=63.07	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
-mean=58.79	median=57.54	min=50.30	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-mean=59.67	median=53.69	min=50.30	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
-mean=57.67	median=57.02	min=50.30	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
-mean=386.43	median=387.23	min=349.69	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-mean=355.17	median=343.12	min=327.48	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
-mean=133.92	median=120.20	min=118.81	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
-mean=212.42	median=214.09	min=191.86	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
-mean=212.72	median=219.80	min=191.86	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
-mean=1303.31	median=1358.03	min=1140.52	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
-mean=1188.27	median=1139.30	min=1085.11	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
-mean=450.78	median=513.62	min=389.86	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
-mean=66.26	median=65.25	min=64.69	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-mean=79.20	median=80.33	min=64.69	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
-mean=459.81	median=447.06	min=406.86	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
-mean=369.01	median=430.87	min=299.09	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
-mean=983.62	median=989.13	min=951.54	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
-mean=996.42	median=979.01	min=942.02	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
-mean=202.69	median=202.09	min=201.07	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
-mean=217.55	median=219.96	min=201.07	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
-mean=200.11	median=234.19	min=169.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
-[ WARN:0@1307.031] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
-mean=200.22	median=203.99	min=169.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
-mean=193.37	median=173.03	min=169.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
-mean=189.89	median=186.60	min=169.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
-mean=189.19	median=204.07	min=169.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
-mean=183.55	median=188.47	min=149.32	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+mean       median     min        input size   model
+4.93       4.91       4.83       [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+5.30       5.31       4.83       [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+60.02      61.00      57.85      [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+70.27      74.77      57.85      [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
+29.36      28.28      27.97      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+34.66      34.12      27.97      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+38.60      37.72      36.79      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+41.57      41.91      36.79      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+70.82      72.70      67.14      [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+64.73      64.22      62.19      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+58.18      59.29      49.97      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+59.15      52.27      49.97      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+57.38      55.13      49.97      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+385.29     361.27     348.96     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+352.90     395.79     328.06     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+122.17     123.58     119.43     [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+208.25     217.96     195.76     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+203.04     213.99     161.37     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+1189.83    1150.85    1138.93    [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+1137.18    1142.89    1080.23    [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+428.66     524.98     391.33     [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+66.91      67.09      64.90      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+79.42      81.44      64.90      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+439.53     431.92     406.03     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+358.63     379.93     296.32     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+5.29       5.30       5.21       [100, 100]   WeChatQRCode with ['detect_2021nov.prototxt', 'detect_2021nov.caffemodel', 'sr_2021nov.prototxt', 'sr_2021nov.caffemodel']
+973.75     968.68     954.58     [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+961.44     959.29     935.29     [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+202.74     202.73     200.75     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+217.07     217.26     200.75     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+199.81     231.31     169.27     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@1277.652] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+199.73     203.96     169.27     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+192.97     175.68     169.27     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+189.65     189.43     169.27     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+188.98     202.49     169.27     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+183.49     188.71     149.81     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+```
+
+NPU (TIMVX):
+
+```
+$ python3 benchmark.py --all --int8 --cfg_overwrite_backend_target 3 --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_TIMVX
+target=cv.dnn.DNN_TARGET_NPU
+mean       median     min        input size   model
+5.67       5.74       5.59       [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+76.97      77.86      75.59      [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
+40.38      39.41      38.12      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+44.36      45.77      42.06      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+60.75      62.46      56.34      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+57.40      58.10      52.11      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+340.20     347.74     330.70     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+200.50     224.02     160.81     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+1103.24    1091.76    1059.77    [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+95.92      102.80     92.77      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+307.90     310.52     302.46     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+178.71     178.87     177.84     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+183.51     183.72     177.84     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+172.06     189.19     149.19     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+```
+
+### Atlas 200 DK
+
+Specs: [details_en](https://e.huawei.com/uk/products/cloud-computing-dc/atlas/atlas-200), [details_cn](https://www.hiascend.com/zh/hardware/developer-kit)
+- (SoC) CPU: 8-core Coretext-A55 @ 1.6GHz (max)
+- NPU: Ascend 310, dual DaVinci AI cores, 22/16/8 TOPS INT8.
+
+CPU:
+
+```
+$ python3 benchmark.py --all --cfg_exclude wechat:dasiamrpn --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_OPENCV
+target=cv.dnn.DNN_TARGET_CPU
+mean       median     min        input size   model
+8.02       8.07       7.93       [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+9.44       9.34       7.93       [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+104.51     112.90     102.07     [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+131.49     147.17     102.07     [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
+47.71      57.86      46.48      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+59.26      59.07      46.48      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+57.95      58.02      57.30      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+65.52      70.76      57.30      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+107.98     127.65     106.59     [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+103.96     124.91     102.87     [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+90.46      90.53      76.14      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+98.40      76.49      76.14      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+98.06      95.36      76.14      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+564.69     556.79     537.84     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+621.54     661.56     537.84     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+226.08     216.89     216.07     [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+343.08     346.39     315.99     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+351.64     346.41     315.99     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+1995.97    1996.82    1967.76    [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+2060.87    2055.60    1967.76    [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+105.23     105.14     105.00     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+123.41     125.65     105.00     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+631.70     631.81     630.61     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+595.32     599.48     565.32     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+1452.55    1453.75    1450.98    [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+1433.26    1432.08    1409.78    [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+299.36     299.92     298.75     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+329.84     333.32     298.75     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+303.65     367.68     262.48     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@760.743] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+299.60     315.91     262.48     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+290.29     263.05     262.48     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+290.41     279.30     262.48     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+294.61     295.36     262.48     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+289.53     279.60     262.48     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```
 
 NPU:
 
 ```
-python3 benchmark.py --all --int8 --cfg_overwrite_backend_target 3 --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+$ 
+```
+
+### Khadas Edge2 (RK3588)
+
+Specs: [details](https://www.khadas.com/edge2)
+- (SoC) CPU: 2.25GHz Quad Core ARM Cortex-A76 + 1.8GHz Quad Core Cortex-A55
+- (SoC) NPU: 6 TOPS INT8
+
+CPU:
+
+```
+python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
 Benchmarking ...
-backend=cv.dnn.DNN_BACKEND_TIMVX
-target=cv.dnn.DNN_TARGET_NPU
-mean=5.71	median=5.70	min=5.63	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
-mean=77.06	median=77.23	min=76.26	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
-mean=40.81	median=39.83	min=38.90	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
-mean=45.59	median=46.33	min=43.45	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
-mean=59.84	median=60.37	min=55.79	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
-mean=56.32	median=57.64	min=51.82	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
-mean=337.28	median=337.06	min=327.04	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
-mean=193.64	median=208.00	min=161.97	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
-mean=1106.77	median=1116.50	min=1065.63	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
-mean=94.99	median=94.49	min=91.96	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
-mean=304.75	median=299.43	min=297.99	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
-mean=178.31	median=178.62	min=177.75	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
-mean=183.10	median=184.61	min=177.75	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
-mean=171.68	median=191.14	min=149.26	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+backend=cv.dnn.DNN_BACKEND_OPENCV
+target=cv.dnn.DNN_TARGET_CPU
+mean       median     min        input size   model
+2.47       2.55       2.44       [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
+2.81       2.84       2.44       [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+33.79      33.83      33.24      [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
+39.96      40.77      33.24      [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
+15.99      16.12      15.92      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+19.09      19.48      15.92      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+20.27      20.45      20.11      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+23.14      23.62      20.11      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+34.58      34.53      33.55      [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+32.78      32.94      31.99      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+28.38      28.80      24.59      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+31.49      24.66      24.59      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+31.45      32.34      24.59      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+178.87     178.49     173.57     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+197.19     200.06     173.57     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+57.57      65.48      51.34      [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+118.38     132.59     88.34      [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
+120.74     110.82     88.34      [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+577.93     577.17     553.81     [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
+607.96     604.88     553.81     [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+152.78     155.89     121.26     [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+38.03      38.26      37.51      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+47.12      48.12      37.51      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+195.67     198.02     182.97     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+181.91     182.28     169.98     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+394.77     407.60     371.95     [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+392.52     404.80     367.96     [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+77.32      77.72      75.27      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+82.93      82.93      75.27      [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+77.51      93.01      67.44      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@598.857] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+77.02      84.11      67.44      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+75.11      69.82      63.98      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+74.55      73.36      63.98      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+75.06      77.44      63.98      [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+73.91      74.25      63.98      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```
 
 ### Toybrick RV1126
 
+Specs: 
+- CPU: 
 
+CPU:
+
+```
+$ 
+```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -188,6 +188,57 @@ mean=264.84	median=276.17	min=230.57	input size=[1280, 720]	model: CRNN with ['t
 mean=259.24	median=249.23	min=224.99	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```
 
-GPU:
+GPU (CUDA-FP32):
 ```
+$ python3 benchmark.py --all --fp32 --cfg_exclude wechat --cfg_overwrite_backend_target 1
+Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_CUDA
+target=cv.dnn.DNN_TARGET_CUDA
+mean=11.88	median=11.42	min=9.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
+mean=24.64	median=24.45	min=24.25	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
+mean=20.56	median=21.16	min=18.78	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+mean=41.09	median=46.72	min=40.55	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+mean=89.74	median=86.81	min=84.49	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+mean=69.14	median=80.06	min=68.81	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+mean=62.03	median=62.19	min=55.37	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+mean=146.98	median=148.92	min=144.63	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+mean=53.37	median=54.02	min=51.89	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+mean=213.78	median=214.45	min=212.26	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
+mean=1233.68	median=1244.26	min=1223.56	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
+mean=76.43	median=75.60	min=74.54	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+mean=61.60	median=65.97	min=58.57	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+mean=127.71	median=127.58	min=125.22	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
+mean=303.00	median=303.69	min=297.90	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+mean=301.84	median=299.22	min=297.08	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+mean=57.34	median=53.10	min=51.87	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+mean=58.70	median=63.59	min=51.87	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+mean=45.11	median=57.01	min=21.63	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+```
+
+GPU (CUDA-FP16):
+
+```
+$ python3 benchmark.py --all --fp32 --cfg_exclude wechat --cfg_overwrite_backend_target 2
+Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_CUDA
+target=cv.dnn.DNN_TARGET_CUDA_FP16
+mean=26.34	median=25.66	min=25.55	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
+mean=111.40	median=111.36	min=110.84	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
+mean=115.56	median=113.08	min=112.66	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+mean=40.77	median=40.71	min=40.55	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+mean=98.94	median=97.82	min=91.00	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+mean=68.83	median=68.54	min=68.40	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+mean=61.39	median=61.97	min=55.02	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+mean=136.91	median=129.33	min=128.82	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+mean=363.36	median=364.91	min=358.08	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+mean=215.61	median=225.95	min=212.47	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
+mean=1221.35	median=1230.06	min=1209.94	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
+mean=52.16	median=52.17	min=50.31	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+mean=213.30	median=218.13	min=208.08	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+mean=92.16	median=89.69	min=87.86	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
+mean=345.59	median=345.03	min=340.60	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+mean=345.38	median=352.14	min=337.76	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+mean=49.97	median=49.72	min=45.73	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+mean=50.40	median=51.25	min=45.73	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+mean=39.68	median=55.06	min=20.87	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -45,6 +45,50 @@ PYTHONPATH=.. python benchmark.py
 
 Benchmark is done with latest `opencv-python==4.7.0.72` and `opencv-contrib-python==4.7.0.72` on the following platforms. Some models are excluded because of support issues.
 
+### Intel 12700K (CPU)
+
+```
+python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar-act_int8-wt_int8-quantized.onnx:human_segmentation_pphumanseg_2023mar-act_int8-wt_int8-quantized.onnx
+Benchmarking ...
+mean=0.72	median=0.70	min=0.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
+mean=0.90	median=0.90	min=0.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar-act_int8-wt_int8-quantized.onnx']
+mean=6.04	median=6.08	min=5.59	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
+mean=7.34	median=7.94	min=5.59	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec-act_int8-wt_int8-quantized.onnx']
+mean=3.16	median=3.37	min=2.87	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+mean=4.14	median=3.98	min=2.87	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july-int8-quantized.onnx']
+mean=4.68	median=4.59	min=4.13	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+mean=4.90	median=4.71	min=4.13	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb-act_int8-wt_int8-quantized.onnx']
+mean=8.81	median=7.37	min=6.53	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+mean=5.90	median=5.87	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+mean=5.97	median=6.66	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+mean=6.34	median=6.01	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr-int8-quantized.onnx']
+mean=6.52	median=7.02	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr-int8-quantized.onnx']
+mean=34.71	median=35.41	min=32.15	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+mean=35.03	median=35.31	min=32.15	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan-act_int8-wt_int8-quantized.onnx']
+mean=8.63	median=7.99	min=7.54	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+mean=66.03	median=64.57	min=61.72	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
+mean=65.78	median=68.48	min=61.72	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+mean=141.20	median=151.61	min=118.97	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
+mean=141.85	median=151.42	min=118.97	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+mean=29.05	median=28.50	min=22.84	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+mean=6.29	median=6.27	min=5.90	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+mean=8.65	median=9.08	min=5.90	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb-act_int8-wt_int8-quantized.onnx']
+mean=30.39	median=29.95	min=29.43	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
+mean=30.71	median=30.73	min=29.43	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov-act_int8-wt_int8-quantized.onnx']
+mean=1.29	median=1.23	min=1.12	input size=[100, 100]	model: WeChatQRCode with ['detect_2021nov.prototxt', 'detect_2021nov.caffemodel', 'sr_2021nov.prototxt', 'sr_2021nov.caffemodel']
+mean=71.03	median=70.79	min=64.87	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+mean=72.31	median=76.96	min=64.87	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+mean=21.33	median=25.27	min=16.34	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+mean=23.07	median=22.38	min=16.34	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+mean=20.16	median=26.50	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@144.899] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+mean=20.58	median=24.46	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+mean=19.28	median=16.05	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+mean=19.27	median=16.80	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+mean=19.55	median=17.81	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov-act_int8-wt_int8-quantized.onnx']
+mean=18.94	median=21.04	min=11.09	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+```
+
 ### Rasberry Pi 4B (CPU)
 
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -312,3 +312,7 @@ mean=178.31	median=178.62	min=177.75	input size=[1280, 720]	model: CRNN with ['t
 mean=183.10	median=184.61	min=177.75	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
 mean=171.68	median=191.14	min=149.26	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```
+
+### Toybrick RV1126
+
+

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -45,26 +45,28 @@ PYTHONPATH=.. python benchmark.py
 
 Benchmark is done with latest `opencv-python==4.7.0.72` and `opencv-contrib-python==4.7.0.72` on the following platforms. Some models are excluded because of support issues.
 
-### Intel 12700K (CPU)
+### Intel 12700K
+
+CPU:
 
 ```
-python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar-act_int8-wt_int8-quantized.onnx:human_segmentation_pphumanseg_2023mar-act_int8-wt_int8-quantized.onnx
+$ python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
 Benchmarking ...
 mean=0.72	median=0.70	min=0.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
-mean=0.90	median=0.90	min=0.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar-act_int8-wt_int8-quantized.onnx']
+mean=0.90	median=0.90	min=0.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
 mean=6.04	median=6.08	min=5.59	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
-mean=7.34	median=7.94	min=5.59	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec-act_int8-wt_int8-quantized.onnx']
+mean=7.34	median=7.94	min=5.59	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
 mean=3.16	median=3.37	min=2.87	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
 mean=4.14	median=3.98	min=2.87	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july-int8-quantized.onnx']
 mean=4.68	median=4.59	min=4.13	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-mean=4.90	median=4.71	min=4.13	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb-act_int8-wt_int8-quantized.onnx']
+mean=4.90	median=4.71	min=4.13	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
 mean=8.81	median=7.37	min=6.53	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
 mean=5.90	median=5.87	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
 mean=5.97	median=6.66	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
 mean=6.34	median=6.01	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr-int8-quantized.onnx']
 mean=6.52	median=7.02	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr-int8-quantized.onnx']
 mean=34.71	median=35.41	min=32.15	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-mean=35.03	median=35.31	min=32.15	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan-act_int8-wt_int8-quantized.onnx']
+mean=35.03	median=35.31	min=32.15	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
 mean=8.63	median=7.99	min=7.54	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
 mean=66.03	median=64.57	min=61.72	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
 mean=65.78	median=68.48	min=61.72	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
@@ -72,9 +74,9 @@ mean=141.20	median=151.61	min=118.97	input size=[640, 640]	model: YoloX with ['o
 mean=141.85	median=151.42	min=118.97	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
 mean=29.05	median=28.50	min=22.84	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
 mean=6.29	median=6.27	min=5.90	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-mean=8.65	median=9.08	min=5.90	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb-act_int8-wt_int8-quantized.onnx']
+mean=8.65	median=9.08	min=5.90	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
 mean=30.39	median=29.95	min=29.43	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
-mean=30.71	median=30.73	min=29.43	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov-act_int8-wt_int8-quantized.onnx']
+mean=30.71	median=30.73	min=29.43	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
 mean=1.29	median=1.23	min=1.12	input size=[100, 100]	model: WeChatQRCode with ['detect_2021nov.prototxt', 'detect_2021nov.caffemodel', 'sr_2021nov.prototxt', 'sr_2021nov.caffemodel']
 mean=71.03	median=70.79	min=64.87	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
 mean=72.31	median=76.96	min=64.87	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
@@ -85,30 +87,32 @@ mean=20.16	median=26.50	min=11.49	input size=[1280, 720]	model: CRNN with ['text
 mean=20.58	median=24.46	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
 mean=19.28	median=16.05	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
 mean=19.27	median=16.80	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
-mean=19.55	median=17.81	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov-act_int8-wt_int8-quantized.onnx']
+mean=19.55	median=17.81	min=11.49	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
 mean=18.94	median=21.04	min=11.09	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```
 
-### Rasberry Pi 4B (CPU)
+### Rasberry Pi 4B
+
+CPU:
 
 ```
-$ python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar-act_int8-wt_int8-quantized.onnx:human_segmentation_pphumanseg_2023mar-act_int8-wt_int8-quantized.onnx
+$ python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
 Benchmarking ...
 mean=5.43	median=5.41	min=5.38	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
-mean=6.09	median=6.19	min=5.38	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar-act_int8-wt_int8-quantized.onnx']
+mean=6.09	median=6.19	min=5.38	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
 mean=78.83	median=78.83	min=78.43	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
-mean=92.56	median=94.20	min=78.43	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec-act_int8-wt_int8-quantized.onnx']
+mean=92.56	median=94.20	min=78.43	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
 mean=32.53	median=32.51	min=32.33	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
 mean=38.61	median=39.19	min=32.33	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july-int8-quantized.onnx']
 mean=43.57	median=43.59	min=43.26	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-mean=46.69	median=47.12	min=43.26	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb-act_int8-wt_int8-quantized.onnx']
+mean=46.69	median=47.12	min=43.26	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
 mean=73.13	median=73.79	min=72.71	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
 mean=72.33	median=72.49	min=72.13	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
 mean=66.56	median=66.92	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
 mean=67.47	median=62.02	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr-int8-quantized.onnx']
 mean=66.01	median=65.53	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr-int8-quantized.onnx']
 mean=463.93	median=463.23	min=459.88	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-mean=441.38	median=434.24	min=373.27	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan-act_int8-wt_int8-quantized.onnx']
+mean=441.38	median=434.24	min=373.27	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
 mean=167.70	median=173.37	min=143.13	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
 mean=225.10	median=223.10	min=208.92	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
 mean=226.14	median=226.32	min=206.70	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
@@ -116,9 +120,9 @@ mean=1805.87	median=1827.43	min=1717.68	input size=[640, 640]	model: YoloX with 
 mean=1737.66	median=1789.99	min=1575.72	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
 mean=712.94	median=701.07	min=580.18	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
 mean=86.83	median=76.78	min=65.25	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-mean=107.26	median=98.07	min=65.25	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb-act_int8-wt_int8-quantized.onnx']
+mean=107.26	median=98.07	min=65.25	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
 mean=625.56	median=622.26	min=599.92	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
-mean=512.76	median=519.71	min=353.70	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov-act_int8-wt_int8-quantized.onnx']
+mean=512.76	median=519.71	min=353.70	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
 mean=5.71	median=5.76	min=5.63	input size=[100, 100]	model: WeChatQRCode with ['detect_2021nov.prototxt', 'detect_2021nov.caffemodel', 'sr_2021nov.prototxt', 'sr_2021nov.caffemodel']
 mean=1862.75	median=1849.26	min=1812.02	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
 mean=1878.45	median=1880.35	min=1812.02	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
@@ -129,6 +133,13 @@ mean=278.11	median=357.83	min=229.71	input size=[1280, 720]	model: CRNN with ['t
 mean=272.00	median=289.96	min=229.71	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
 mean=261.77	median=273.49	min=228.71	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
 mean=254.22	median=253.40	min=226.83	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
-mean=251.15	median=260.79	min=226.83	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov-act_int8-wt_int8-quantized.onnx']
+mean=251.15	median=260.79	min=226.83	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
 mean=242.05	median=245.09	min=190.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+```
+
+### Jetson Nano B01
+
+CPU:
+
+```
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -242,3 +242,73 @@ mean=49.97	median=49.72	min=45.73	input size=[1280, 720]	model: CRNN with ['text
 mean=50.40	median=51.25	min=45.73	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
 mean=39.68	median=55.06	min=20.87	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
 ```
+
+### Khadas VIM3
+
+CPU:
+
+```
+$ python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_OPENCV
+target=cv.dnn.DNN_TARGET_CPU
+mean=4.88	median=4.95	min=4.78	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
+mean=5.28	median=5.36	min=4.78	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+mean=61.12	median=61.16	min=58.08	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
+mean=70.74	median=70.32	min=58.08	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
+mean=29.07	median=37.91	min=28.24	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+mean=34.33	median=33.97	min=28.24	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+mean=38.71	median=38.17	min=37.07	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+mean=41.70	median=42.95	min=37.07	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+mean=70.71	median=70.68	min=66.49	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+mean=67.46	median=65.78	min=63.07	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+mean=58.79	median=57.54	min=50.30	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+mean=59.67	median=53.69	min=50.30	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+mean=57.67	median=57.02	min=50.30	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+mean=386.43	median=387.23	min=349.69	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+mean=355.17	median=343.12	min=327.48	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+mean=133.92	median=120.20	min=118.81	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+mean=212.42	median=214.09	min=191.86	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
+mean=212.72	median=219.80	min=191.86	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+mean=1303.31	median=1358.03	min=1140.52	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
+mean=1188.27	median=1139.30	min=1085.11	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+mean=450.78	median=513.62	min=389.86	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+mean=66.26	median=65.25	min=64.69	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+mean=79.20	median=80.33	min=64.69	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+mean=459.81	median=447.06	min=406.86	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
+mean=369.01	median=430.87	min=299.09	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+mean=983.62	median=989.13	min=951.54	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+mean=996.42	median=979.01	min=942.02	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+mean=202.69	median=202.09	min=201.07	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+mean=217.55	median=219.96	min=201.07	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+mean=200.11	median=234.19	min=169.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@1307.031] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+mean=200.22	median=203.99	min=169.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+mean=193.37	median=173.03	min=169.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+mean=189.89	median=186.60	min=169.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+mean=189.19	median=204.07	min=169.53	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+mean=183.55	median=188.47	min=149.32	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+```
+
+NPU:
+
+```
+python3 benchmark.py --all --int8 --cfg_overwrite_backend_target 3 --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_TIMVX
+target=cv.dnn.DNN_TARGET_NPU
+mean=5.71	median=5.70	min=5.63	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+mean=77.06	median=77.23	min=76.26	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
+mean=40.81	median=39.83	min=38.90	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+mean=45.59	median=46.33	min=43.45	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+mean=59.84	median=60.37	min=55.79	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+mean=56.32	median=57.64	min=51.82	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+mean=337.28	median=337.06	min=327.04	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+mean=193.64	median=208.00	min=161.97	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+mean=1106.77	median=1116.50	min=1065.63	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+mean=94.99	median=94.49	min=91.96	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+mean=304.75	median=299.43	min=297.99	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+mean=178.31	median=178.62	min=177.75	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+mean=183.10	median=184.61	min=177.75	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+mean=171.68	median=191.14	min=149.26	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -19,7 +19,25 @@ Data for benchmarking will be downloaded and loaded in [data](./data) based on g
 
 ```shell
 export PYTHONPATH=$PYTHONPATH:.. 
+
+# Single config
 python benchmark.py --cfg ./config/face_detection_yunet.yaml
+
+# All configs
+python benchmark.py --all
+
+# All configs but only fp32 models (--fp32, --fp16, --int8 are available for now)
+python benchmark.py --all --fp32
+
+# All configs but exclude some of them (fill with config name keywords, not sensitive to upper/lower case, seperate with colons)
+python benchmark.py --all --cfg_exclude wechat
+python benchmark.py --all --cfg_exclude wechat:dasiamrpn
+
+# All configs but exclude some of the models (fill with exact model names, sensitive to upper/lower case, seperate with colons)
+python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+
+# All configs with overwritten backend and target (run with --help to get available combinations)
+python benchmark.py --all --cfg_overwrite_backend_target 1
 ```
 
 **Windows**:
@@ -34,12 +52,6 @@ python benchmark.py --cfg ./config/face_detection_yunet.yaml
     $env:PYTHONPATH=$env:PYTHONPATH+";.."
     python benchmark.py --cfg ./config/face_detection_yunet.yaml
     ```
-<!--
-Omit `--cfg` if you want to benchmark all included models:
-```shell
-PYTHONPATH=.. python benchmark.py
-```
--->
 
 ## Detailed Results
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -52,19 +52,21 @@ CPU:
 ```
 $ python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
 Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_OPENCV
+target=cv.dnn.DNN_TARGET_CPU
 mean=0.72	median=0.70	min=0.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
 mean=0.90	median=0.90	min=0.62	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
 mean=6.04	median=6.08	min=5.59	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
 mean=7.34	median=7.94	min=5.59	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
 mean=3.16	median=3.37	min=2.87	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-mean=4.14	median=3.98	min=2.87	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july-int8-quantized.onnx']
+mean=4.14	median=3.98	min=2.87	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
 mean=4.68	median=4.59	min=4.13	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
 mean=4.90	median=4.71	min=4.13	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
 mean=8.81	median=7.37	min=6.53	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
 mean=5.90	median=5.87	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
 mean=5.97	median=6.66	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-mean=6.34	median=6.01	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr-int8-quantized.onnx']
-mean=6.52	median=7.02	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr-int8-quantized.onnx']
+mean=6.34	median=6.01	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+mean=6.52	median=7.02	min=5.10	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
 mean=34.71	median=35.41	min=32.15	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
 mean=35.03	median=35.31	min=32.15	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
 mean=8.63	median=7.99	min=7.54	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
@@ -98,19 +100,21 @@ CPU:
 ```
 $ python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
 Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_OPENCV
+target=cv.dnn.DNN_TARGET_CPU
 mean=5.43	median=5.41	min=5.38	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
 mean=6.09	median=6.19	min=5.38	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
 mean=78.83	median=78.83	min=78.43	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
 mean=92.56	median=94.20	min=78.43	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
 mean=32.53	median=32.51	min=32.33	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-mean=38.61	median=39.19	min=32.33	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july-int8-quantized.onnx']
+mean=38.61	median=39.19	min=32.33	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
 mean=43.57	median=43.59	min=43.26	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
 mean=46.69	median=47.12	min=43.26	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
 mean=73.13	median=73.79	min=72.71	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
 mean=72.33	median=72.49	min=72.13	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
 mean=66.56	median=66.92	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-mean=67.47	median=62.02	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr-int8-quantized.onnx']
-mean=66.01	median=65.53	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr-int8-quantized.onnx']
+mean=67.47	median=62.02	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+mean=66.01	median=65.53	min=61.25	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
 mean=463.93	median=463.23	min=459.88	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
 mean=441.38	median=434.24	min=373.27	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
 mean=167.70	median=173.37	min=143.13	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
@@ -141,5 +145,49 @@ mean=242.05	median=245.09	min=190.53	input size=[1280, 720]	model: CRNN with ['t
 
 CPU:
 
+```
+$ python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
+Benchmarking ...
+backend=cv.dnn.DNN_BACKEND_OPENCV
+target=cv.dnn.DNN_TARGET_CPU
+mean=5.29	median=5.29	min=5.23	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar.onnx']
+mean=6.03	median=6.18	min=5.23	input size=[160, 120]	model: YuNet with ['face_detection_yunet_2022mar_int8.onnx']
+mean=65.42	median=65.37	min=65.20	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec.onnx']
+mean=79.12	median=79.78	min=65.20	input size=[150, 150]	model: SFace with ['face_recognition_sface_2021dec_int8.onnx']
+mean=28.28	median=28.30	min=28.12	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
+mean=34.87	median=35.71	min=28.12	input size=[112, 112]	model: FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
+mean=40.87	median=40.84	min=40.71	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
+mean=44.14	median=44.28	min=40.71	input size=[224, 224]	model: MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
+mean=65.94	median=65.86	min=65.72	input size=[192, 192]	model: PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
+mean=69.17	median=69.04	min=68.84	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
+mean=62.20	median=62.36	min=55.52	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
+mean=66.22	median=55.93	min=55.52	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
+mean=65.34	median=75.35	min=55.52	input size=[224, 224]	model: MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
+mean=374.52	median=383.78	min=367.81	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
+mean=389.18	median=408.69	min=367.81	input size=[224, 224]	model: PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
+mean=130.63	median=131.11	min=128.36	input size=[320, 240]	model: LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
+mean=214.30	median=212.83	min=212.53	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov.onnx']
+mean=216.49	median=220.40	min=212.53	input size=[416, 416]	model: NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
+mean=1225.13	median=1234.78	min=1213.85	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov.onnx']
+mean=1256.33	median=1261.81	min=1213.85	input size=[640, 640]	model: YoloX with ['object_detection_yolox_2022nov_int8.onnx']
+mean=471.54	median=492.74	min=450.43	input size=[1280, 720]	model: DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
+mean=70.52	median=70.05	min=69.65	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
+mean=82.59	median=82.46	min=69.65	input size=[192, 192]	model: MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
+mean=420.32	median=414.19	min=410.95	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov.onnx']
+mean=375.09	median=384.11	min=333.25	input size=[128, 256]	model: YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
+mean=1106.86	median=1093.50	min=1090.64	input size=[640, 480]	model: DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+mean=1104.27	median=1106.12	min=1086.68	input size=[640, 480]	model: DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
+mean=281.11	median=296.92	min=276.23	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
+mean=297.92	median=302.00	min=276.23	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
+mean=277.85	median=313.29	min=240.38	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
+[ WARN:0@1524.821] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
+mean=275.41	median=299.86	min=240.38	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
+mean=265.87	median=241.65	min=230.57	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
+mean=264.09	median=255.31	min=230.57	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
+mean=264.84	median=276.17	min=230.57	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
+mean=259.24	median=249.23	min=224.99	input size=[1280, 720]	model: CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
+```
+
+GPU:
 ```
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -41,14 +41,16 @@ PYTHONPATH=.. python benchmark.py
 ```
 -->
 
-## More Results
+## Detailed Results
 
 Benchmark is done with latest `opencv-python==4.7.0.72` and `opencv-contrib-python==4.7.0.72` on the following platforms. Some models are excluded because of support issues.
 
 ### Intel 12700K
 
-Specs: [details](https://www.intel.com/content/www/us/en/products/sku/82931/intel-core-i75930k-processor-15m-cache-up-to-3-70-ghz/specifications.html)
-- CPU: 3.50GHz, 6 cores, 12 threads.
+Specs: [details](https://www.intel.com/content/www/us/en/products/sku/134594/intel-core-i712700k-processor-25m-cache-up-to-5-00-ghz/specifications.html)
+- CPU: 8 Performance-cores, 4 Efficient-cores, 20 threads
+  - Performance-core: 3.60 GHz base freq, turbo up to 4.90 GHz
+  - Efficient-core: 2.70 GHz base freq, turbo up to 3.80 GHz
 
 CPU: 
 
@@ -100,7 +102,7 @@ mean       median     min        input size   model
 ### Rasberry Pi 4B
 
 Specs: [details](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/)
-- CPU: Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.5GHz.
+- CPU: Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.5 GHz.
 
 CPU:
 
@@ -262,7 +264,7 @@ mean       median     min        input size   model
 ### Khadas VIM3
 
 Specs: [details](https://www.khadas.com/vim3)
-- (SoC) CPU: Amlogic A311D, 2.2GHz Quad core ARM Cortex-A73 and 1.8GHz dual core Cortex-A53
+- (SoC) CPU: Amlogic A311D, 2.2 GHz Quad core ARM Cortex-A73 and 1.8 GHz dual core Cortex-A53
 - NPU: 5 TOPS Performance NPU INT8 inference up to 1536 MAC Supports all major deep learning frameworks including TensorFlow and Caffe 
 
 CPU:
@@ -339,7 +341,7 @@ mean       median     min        input size   model
 ### Atlas 200 DK
 
 Specs: [details_en](https://e.huawei.com/uk/products/cloud-computing-dc/atlas/atlas-200), [details_cn](https://www.hiascend.com/zh/hardware/developer-kit)
-- (SoC) CPU: 8-core Coretext-A55 @ 1.6GHz (max)
+- (SoC) CPU: 8-core Coretext-A55 @ 1.6 GHz (max)
 - NPU: Ascend 310, dual DaVinci AI cores, 22/16/8 TOPS INT8.
 
 CPU:
@@ -411,176 +413,4 @@ mean       median     min        input size   model
 5.58       5.57       5.54       [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
 17.15      17.18      16.83      [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
 17.95      18.61      16.83      [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
-```
-
-### Khadas Edge2 (RK3588)
-
-Specs: [details](https://www.khadas.com/edge2)
-- (SoC) CPU: 2.25GHz Quad Core ARM Cortex-A76 + 1.8GHz Quad Core Cortex-A55
-<!--
-- (SoC) NPU: 6 TOPS INT8
--->
-
-CPU:
-
-```
-python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
-Benchmarking ...
-backend=cv.dnn.DNN_BACKEND_OPENCV
-target=cv.dnn.DNN_TARGET_CPU
-mean       median     min        input size   model
-2.47       2.55       2.44       [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
-2.81       2.84       2.44       [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
-33.79      33.83      33.24      [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
-39.96      40.77      33.24      [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
-15.99      16.12      15.92      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-19.09      19.48      15.92      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
-20.27      20.45      20.11      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-23.14      23.62      20.11      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
-34.58      34.53      33.55      [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
-32.78      32.94      31.99      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
-28.38      28.80      24.59      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-31.49      24.66      24.59      [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
-31.45      32.34      24.59      [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
-178.87     178.49     173.57     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-197.19     200.06     173.57     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
-57.57      65.48      51.34      [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
-118.38     132.59     88.34      [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
-120.74     110.82     88.34      [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
-577.93     577.17     553.81     [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
-607.96     604.88     553.81     [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
-152.78     155.89     121.26     [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
-38.03      38.26      37.51      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-47.12      48.12      37.51      [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
-195.67     198.02     182.97     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
-181.91     182.28     169.98     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
-394.77     407.60     371.95     [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
-392.52     404.80     367.96     [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
-77.32      77.72      75.27      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
-82.93      82.93      75.27      [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
-77.51      93.01      67.44      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
-[ WARN:0@598.857] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
-77.02      84.11      67.44      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
-75.11      69.82      63.98      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
-74.55      73.36      63.98      [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
-75.06      77.44      63.98      [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
-73.91      74.25      63.98      [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
-```
-
-### Horizon Sunrise X3 PI
-
-Specs: [details_cn](https://developer.horizon.ai/sunrise)
-- CPU: ARM Cortex-A53，4xCore, 1.2G
-- BPU (aka NPU): (Bernoulli Arch) 2×Core，up to 1.0G, ~5Tops
-
-```
-$ python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
-Benchmarking ...
-backend=cv.dnn.DNN_BACKEND_OPENCV
-target=cv.dnn.DNN_TARGET_CPU
-mean       median     min        input size   model
-11.04      11.01      10.98      [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
-12.59      12.75      10.98      [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
-140.83     140.85     140.52     [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
-171.71     175.65     140.52     [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
-64.96      64.94      64.77      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-80.20      81.82      64.77      [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
-80.67      80.72      80.45      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-89.25      90.39      80.45      [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
-144.23     144.34     143.84     [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
-140.60     140.62     140.33     [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
-122.53     124.23     107.71     [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-128.22     107.87     107.71     [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
-125.77     123.77     107.71     [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
-759.81     760.01     759.11     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-764.17     764.43     759.11     [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
-283.75     284.17     282.15     [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
-408.16     408.31     402.71     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
-408.82     407.99     402.71     [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
-2749.22    2756.23    2737.96    [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
-2671.54    2692.18    2601.24    [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
-929.63     936.01     914.86     [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
-142.23     142.03     141.78     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-179.74     184.79     141.78     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
-898.23     897.52     896.58     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
-749.83     765.90     630.39     [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
-1908.87    1905.00    1903.13    [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
-1922.34    1920.65    1896.97    [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
-470.78     469.17     467.92     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
-495.94     497.12     467.92     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
-464.58     528.72     408.69     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
-[ WARN:0@2820.735] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
-465.04     467.01     408.69     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
-452.90     409.34     408.69     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
-450.23     438.57     408.69     [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
-453.52     468.72     408.69     [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
-443.38     447.29     381.90     [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
-```
-
-
-### MAIX-III AX-PI
-
-Specs: [details_en](https://wiki.sipeed.com/hardware/en/maixIII/ax-pi/axpi.html#Hardware), [details_cn](https://wiki.sipeed.com/hardware/zh/maixIII/ax-pi/axpi.html#%E7%A1%AC%E4%BB%B6%E5%8F%82%E6%95%B0)
-- CPU: Quad cores ARM Cortex-A7
-<!--
-- NPU: 14.4Tops@int4，3.6Tops@int8
--->
-
-CPU:
-
-```
-```
-
-### Toybrick RV1126
-
-Specs: [details](https://t.rock-chips.com/en/portal.php?mod=view&aid=26)
-- CPU: Quard core ARM Cortex-A7, up to 1.5GHz
-<!--
-- NPU: 2.0TOPS INT8 (not supported by OpenCV DNN)
--->
-
-CPU:
-
-```
-$ python3 benchmark.py --all --cfg_exclude wechat --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
-Benchmarking ...
-backend=cv.dnn.DNN_BACKEND_OPENCV
-target=cv.dnn.DNN_TARGET_CPU
-mean       median     min        input size   model
-68.89      68.59      68.23      [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
-60.98      61.11      52.00      [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
-1550.71    1578.99    1527.58    [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
-1214.15    1261.66    920.50     [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
-604.36     611.24     578.99     [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
-496.42     537.75     397.23     [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
-460.56     470.15     440.77     [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
-387.63     379.96     318.71     [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb_int8.onnx']
-1610.78    1599.92    1583.95    [192, 192]   PPHumanSeg with ['human_segmentation_pphumanseg_2023mar.onnx']
-1546.16    1539.50    1513.14    [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr.onnx']
-1166.56    1211.97    827.10     [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr.onnx']
-983.80     868.18     689.32     [224, 224]   MobileNet with ['image_classification_mobilenetv1_2022apr_int8.onnx']
-840.38     801.83     504.54     [224, 224]   MobileNet with ['image_classification_mobilenetv2_2022apr_int8.onnx']
-11793.09   11817.73   11741.04   [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan.onnx']
-7740.03    8134.99    4464.30    [224, 224]   PPResNet with ['image_classification_ppresnet50_2022jan_int8.onnx']
-3222.92    3225.18    3170.71    [320, 240]   LPD_YuNet with ['license_plate_detection_lpd_yunet_2023mar.onnx']
-2303.55    2307.46    2289.41    [416, 416]   NanoDet with ['object_detection_nanodet_2022nov.onnx']
-1888.15    1920.41    1528.78    [416, 416]   NanoDet with ['object_detection_nanodet_2022nov_int8.onnx']
-38359.93   39021.21   37180.85   [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
-24504.50   25439.34   13443.63   [640, 640]   YoloX with ['object_detection_yolox_2022nov_int8.onnx']
-14738.64   14764.84   14655.76   [1280, 720]  DaSiamRPN with ['object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx', 'object_tracking_dasiamrpn_kernel_r1_2021nov.onnx', 'object_tracking_dasiamrpn_model_2021nov.onnx']
-872.09     877.72     838.99     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
-764.48     775.55     653.25     [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb_int8.onnx']
-11117.07   11109.12   11058.49   [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
-7037.96    7424.89    3750.12    [128, 256]   YoutuReID with ['person_reid_youtu_2021nov_int8.onnx']
-49065.03   49144.55   48943.50   [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
-49052.24   48992.64   48927.44   [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
-2200.08    2193.78    2175.77    [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2021sep.onnx']
-2244.03    2240.25    2175.77    [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov.onnx']
-2230.12    2290.28    2175.77    [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2021sep.onnx']
-[ WARN:0@1315.065] global onnx_graph_simplifier.cpp:804 getMatFromTensor DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.
-2220.33    2281.75    2171.61    [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2023feb_fp16.onnx']
-2216.44    2212.48    2171.61    [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2023feb_fp16.onnx']
-2041.65    2209.50    1268.91    [1280, 720]  CRNN with ['text_recognition_CRNN_CH_2022oct_int8.onnx']
-1933.06    2210.81    1268.91    [1280, 720]  CRNN with ['text_recognition_CRNN_CN_2021nov_int8.onnx']
-1826.34    2234.66    1184.53    [1280, 720]  CRNN with ['text_recognition_CRNN_EN_2022oct_int8.onnx']
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -391,7 +391,7 @@ mean       median     min        input size   model
 NPU:
 
 ```
-$ python3 benchmark.py --all --fp32 --cfg_exclude wechat:dasiamrpn:db:crnn --cfg_overwrite_backend_target 4
+$ python3 benchmark.py --all --fp32 --cfg_exclude wechat:dasiamrpn:crnn --cfg_overwrite_backend_target 4
 Benchmarking ...
 backend=cv.dnn.DNN_BACKEND_CANN
 target=cv.dnn.DNN_TARGET_NPU
@@ -409,6 +409,8 @@ mean       median     min        input size   model
 28.59      28.60      27.91      [640, 640]   YoloX with ['object_detection_yolox_2022nov.onnx']
 5.17       5.26       5.09       [192, 192]   MPPalmDet with ['palm_detection_mediapipe_2023feb.onnx']
 5.58       5.57       5.54       [128, 256]   YoutuReID with ['person_reid_youtu_2021nov.onnx']
+17.15      17.18      16.83      [640, 480]   DB with ['text_detection_DB_IC15_resnet18_2021sep.onnx']
+17.95      18.61      16.83      [640, 480]   DB with ['text_detection_DB_TD500_resnet18_2021sep.onnx']
 ```
 
 ### Khadas Edge2 (RK3588)

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -33,9 +33,11 @@ parser.add_argument('--cfg_overwrite_backend_target', type=int, default=-1,
                         {:d}: TIM-VX + NPU,
                         {:d}: CANN + NPU
                     '''.format(*[x for x in range(len(backend_target_pairs))]))
-parser.add_argument("--fp32", action="store_true", help="Runs models of float32 precision only.")
-parser.add_argument("--fp16", action="store_true", help="Runs models of float16 precision only.")
-parser.add_argument("--int8", action="store_true", help="Runs models of int8 precision only.")
+parser.add_argument("--cfg_exclude", type=str, help="Configs to exclude when using --all. Split keywords with colons (:). Not sensitive to upper/lower case.")
+parser.add_argument("--fp32", action="store_true", help="Benchmark models of float32 precision only.")
+parser.add_argument("--fp16", action="store_true", help="Benchmark models of float16 precision only.")
+parser.add_argument("--int8", action="store_true", help="Benchmark models of int8 precision only.")
+parser.add_argument("--all", action="store_true", help="Benchmark all models")
 args = parser.parse_args()
 
 def build_from_cfg(cfg, registery, key=None, name=None):
@@ -100,6 +102,7 @@ class Benchmark:
         self._target = available_targets[target_id]
 
         self._benchmark_results = dict()
+        self._benchmark_results_brief = dict()
 
     def setBackendAndTarget(self, backend_id, target_id):
         self._backend = backend_id
@@ -110,56 +113,87 @@ class Benchmark:
 
         for idx, data in enumerate(self._dataloader):
             filename, input_data = data[:2]
-            if filename not in self._benchmark_results:
-                self._benchmark_results[filename] = dict()
+
             if isinstance(input_data, np.ndarray):
                 size = [input_data.shape[1], input_data.shape[0]]
             else:
                 size = input_data.getFrameSize()
-            self._benchmark_results[filename][str(size)] = self._metric.forward(model, *data[1:])
 
-    def printResults(self):
-        for imgName, results in self._benchmark_results.items():
-            print('  image: {}'.format(imgName))
-            total_latency = 0
-            for key, latency in results.items():
-                total_latency += latency
-                print('      {}, latency ({}): {:.4f} ms'.format(key, self._metric.getReduction(), latency))
+            if str(size) not in self._benchmark_results:
+                self._benchmark_results[str(size)] = dict()
+            self._benchmark_results[str(size)][filename] = self._metric.forward(model, *data[1:])
+
+            if str(size) not in self._benchmark_results_brief:
+                self._benchmark_results_brief[str(size)] = []
+            self._benchmark_results_brief[str(size)] += self._benchmark_results[str(size)][filename]
+            
+
+    def printResults(self, model_name, model_path):
+        for imgSize, res in self._benchmark_results_brief.items():
+            mean, median, minimum = self._metric.getPerfStats(res)
+            print("mean={:.2f}, median={:.2f}, min={:.2f}, input size={}, model: {} with {}".format(
+                mean, median, minimum, imgSize, model_name, model_path
+            ))
 
 if __name__ == '__main__':
-    assert args.cfg.endswith('yaml'), 'Currently support configs of yaml format only.'
-    with open(args.cfg, 'r') as f:
-        cfg = yaml.safe_load(f)
-
-    # Instantiate benchmark
-    benchmark = Benchmark(**cfg['Benchmark'])
-
     if args.cfg_overwrite_backend_target >= 0:
         backend_id = backend_target_pairs[args.backend_target][0]
         target_id = backend_target_pairs[args.backend_target][1]
         benchmark.setBackendAndTarget(backend_id, target_id)
 
-    # Instantiate model
-    model_config = cfg['Model']
-    model_handler, model_paths = MODELS.get(model_config.pop('name'))
+    cfgs = []
+    if args.cfg is not None:
+        assert args.cfg.endswith('yaml'), 'Currently support configs of yaml format only.'
+        with open(args.cfg, 'r') as f:
+            cfg = yaml.safe_load(f)
+        cfgs.append(cfg)
+    elif args.all:
+        excludes = []
+        if args.cfg_exclude is not None:
+            excludes = args.cfg_exclude.split(":")
+        # print(excludes)
 
-    _model_paths = []
-    if args.fp32 or args.fp16 or args.int8:
-        if args.fp32:
-            _model_paths += model_paths['fp32']
-        if args.fp16:
-            _model_paths += model_paths['fp16']
-        if args.int8:
-            _model_paths += model_paths['int8']
+        for cfg_fname in sorted(os.listdir("config")):
+            skip_flag = False
+            for exc in excludes:
+                if exc.lower() in cfg_fname.lower():
+                    skip_flag = True
+            if skip_flag:
+                print("{} is skipped.".format(cfg_fname))
+                continue
+
+            assert cfg_fname.endswith("yaml"), "Currently support yaml configs only."
+            with open(os.path.join("config", cfg_fname), "r") as f:
+                cfg = yaml.safe_load(f)
+            cfgs.append(cfg)
     else:
-        _model_paths = model_paths['fp32'] + model_paths['fp16'] + model_paths['int8']
+        raise NotImplementedError("Specify either one config or use flag --all for benchmark.")
 
-    for model_path in _model_paths:
-        model = model_handler(*model_path, **model_config)
-        # Format model_path
-        for i in range(len(model_path)):
-            model_path[i] = model_path[i].split('/')[-1]
-        print('Benchmarking {} with {}'.format(model.name, model_path))
-        # Run benchmark
-        benchmark.run(model)
-        benchmark.printResults()
+    print("Benchmarking ...")
+    for cfg in cfgs:
+        # Instantiate benchmark
+        benchmark = Benchmark(**cfg['Benchmark'])
+
+        # Instantiate model
+        model_config = cfg['Model']
+        model_handler, model_paths = MODELS.get(model_config.pop('name'))
+
+        _model_paths = []
+        if args.fp32 or args.fp16 or args.int8:
+            if args.fp32:
+                _model_paths += model_paths['fp32']
+            if args.fp16:
+                _model_paths += model_paths['fp16']
+            if args.int8:
+                _model_paths += model_paths['int8']
+        else:
+            _model_paths = model_paths['fp32'] + model_paths['fp16'] + model_paths['int8']
+
+        for model_path in _model_paths:
+            model = model_handler(*model_path, **model_config)
+            # Format model_path
+            for i in range(len(model_path)):
+                model_path[i] = model_path[i].split('/')[-1]
+            # Run benchmark
+            benchmark.run(model)
+            benchmark.printResults(model.name, model_path)

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -20,6 +20,13 @@ backend_target_pairs = [
     [cv.dnn.DNN_BACKEND_TIMVX,  cv.dnn.DNN_TARGET_NPU],
     [cv.dnn.DNN_BACKEND_CANN,   cv.dnn.DNN_TARGET_NPU]
 ]
+backend_target_str_pairs = [
+    ["cv.dnn.DNN_BACKEND_OPENCV", "cv.dnn.DNN_TARGET_CPU"],
+    ["cv.dnn.DNN_BACKEND_CUDA",   "cv.dnn.DNN_TARGET_CUDA"],
+    ["cv.dnn.DNN_BACKEND_CUDA",   "cv.dnn.DNN_TARGET_CUDA_FP16"],
+    ["cv.dnn.DNN_BACKEND_TIMVX",  "cv.dnn.DNN_TARGET_NPU"],
+    ["cv.dnn.DNN_BACKEND_CANN",   "cv.dnn.DNN_TARGET_NPU"]
+]
 
 parser = argparse.ArgumentParser("Benchmarks for OpenCV Zoo.")
 parser.add_argument('--cfg', '-c', type=str,
@@ -136,11 +143,6 @@ class Benchmark:
             ))
 
 if __name__ == '__main__':
-    if args.cfg_overwrite_backend_target >= 0:
-        backend_id = backend_target_pairs[args.backend_target][0]
-        target_id = backend_target_pairs[args.backend_target][1]
-        benchmark.setBackendAndTarget(backend_id, target_id)
-
     cfgs = []
     if args.cfg is not None:
         assert args.cfg.endswith('yaml'), 'Currently support configs of yaml format only.'
@@ -169,9 +171,20 @@ if __name__ == '__main__':
         raise NotImplementedError("Specify either one config or use flag --all for benchmark.")
 
     print("Benchmarking ...")
+    if args.cfg_overwrite_backend_target >= 0:
+        backend_str = backend_target_str_pairs[args.cfg_overwrite_backend_target][0]
+        target_str = backend_target_str_pairs[args.cfg_overwrite_backend_target][1]
+        print("backend={}".format(backend_str))
+        print("target={}".format(target_str))
     for cfg in cfgs:
         # Instantiate benchmark
         benchmark = Benchmark(**cfg['Benchmark'])
+
+        # Set backend and target
+        if args.cfg_overwrite_backend_target >= 0:
+            backend_id = backend_target_pairs[args.cfg_overwrite_backend_target][0]
+            target_id = backend_target_pairs[args.cfg_overwrite_backend_target][1]
+            benchmark.setBackendAndTarget(backend_id, target_id)
 
         # Instantiate model
         model_config = cfg['Model']

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -131,7 +131,7 @@ class Benchmark:
     def printResults(self, model_name, model_path):
         for imgSize, res in self._benchmark_results_brief.items():
             mean, median, minimum = self._metric.getPerfStats(res)
-            print("mean={:.2f}, median={:.2f}, min={:.2f}, input size={}, model: {} with {}".format(
+            print("mean={:.2f}\tmedian={:.2f}\tmin={:.2f}\tinput size={}\tmodel: {} with {}".format(
                 mean, median, minimum, imgSize, model_name, model_path
             ))
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -126,7 +126,6 @@ class Benchmark:
             if str(size) not in self._benchmark_results_brief:
                 self._benchmark_results_brief[str(size)] = []
             self._benchmark_results_brief[str(size)] += self._benchmark_results[str(size)][filename]
-            
 
     def printResults(self, model_name, model_path):
         for imgSize, res in self._benchmark_results_brief.items():
@@ -151,7 +150,6 @@ if __name__ == '__main__':
         excludes = []
         if args.cfg_exclude is not None:
             excludes = args.cfg_exclude.split(":")
-        # print(excludes)
 
         for cfg_fname in sorted(os.listdir("config")):
             skip_flag = False
@@ -159,7 +157,7 @@ if __name__ == '__main__':
                 if exc.lower() in cfg_fname.lower():
                     skip_flag = True
             if skip_flag:
-                print("{} is skipped.".format(cfg_fname))
+                # print("{} is skipped.".format(cfg_fname))
                 continue
 
             assert cfg_fname.endswith("yaml"), "Currently support yaml configs only."

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -138,7 +138,7 @@ class Benchmark:
     def printResults(self, model_name, model_path):
         for imgSize, res in self._benchmark_results_brief.items():
             mean, median, minimum = self._metric.getPerfStats(res)
-            print("mean={:.2f}\tmedian={:.2f}\tmin={:.2f}\tinput size={}\tmodel: {} with {}".format(
+            print("{:<10.2f} {:<10.2f} {:<10.2f} {:<12} {} with {}".format(
                 mean, median, minimum, imgSize, model_name, model_path
             ))
 
@@ -177,6 +177,7 @@ if __name__ == '__main__':
         target_str = backend_target_str_pairs[backend_target_id][1]
         print("backend={}".format(backend_str))
         print("target={}".format(target_str))
+    print("{:<10} {:<10} {:<10} {:<12} {}".format("mean", "median", "min", "input size", "model"))
     for cfg in cfgs:
         # Instantiate benchmark
         benchmark = Benchmark(**cfg['Benchmark'])

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -171,9 +171,10 @@ if __name__ == '__main__':
         raise NotImplementedError("Specify either one config or use flag --all for benchmark.")
 
     print("Benchmarking ...")
-    if args.cfg_overwrite_backend_target >= 0:
-        backend_str = backend_target_str_pairs[args.cfg_overwrite_backend_target][0]
-        target_str = backend_target_str_pairs[args.cfg_overwrite_backend_target][1]
+    if args.all:
+        backend_target_id = args.cfg_overwrite_backend_target if args.cfg_overwrite_backend_target >= 0 else 0
+        backend_str = backend_target_str_pairs[backend_target_id][0]
+        target_str = backend_target_str_pairs[backend_target_id][1]
         print("backend={}".format(backend_str))
         print("target={}".format(target_str))
     for cfg in cfgs:

--- a/benchmark/config/face_detection_yunet.yaml
+++ b/benchmark/config/face_detection_yunet.yaml
@@ -10,7 +10,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/face_detection_yunet.yaml
+++ b/benchmark/config/face_detection_yunet.yaml
@@ -6,7 +6,6 @@ Benchmark:
     files: ["group.jpg", "concerts.jpg", "dance.jpg"]
     sizes: # [[w1, h1], ...], Omit to run at original scale
       - [160, 120]
-      - [640, 480]
   metric:
     warmup: 30
     repeat: 10

--- a/benchmark/config/face_recognition_sface.yaml
+++ b/benchmark/config/face_recognition_sface.yaml
@@ -7,7 +7,6 @@ Benchmark:
   metric: # 'sizes' is omitted since this model requires input of fixed size
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/facial_expression_recognition.yaml
+++ b/benchmark/config/facial_expression_recognition.yaml
@@ -7,7 +7,6 @@ Benchmark:
   metric: # 'sizes' is omitted since this model requires input of fixed size
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/handpose_estimation_mediapipe.yaml
+++ b/benchmark/config/handpose_estimation_mediapipe.yaml
@@ -9,7 +9,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/human_segmentation_pphumanseg.yaml
+++ b/benchmark/config/human_segmentation_pphumanseg.yaml
@@ -9,7 +9,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/image_classification_mobilenet.yaml
+++ b/benchmark/config/image_classification_mobilenet.yaml
@@ -10,7 +10,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/image_classification_ppresnet.yaml
+++ b/benchmark/config/image_classification_ppresnet.yaml
@@ -10,7 +10,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/license_plate_detection_yunet.yaml
+++ b/benchmark/config/license_plate_detection_yunet.yaml
@@ -9,7 +9,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/object_detection_nanodet.yaml
+++ b/benchmark/config/object_detection_nanodet.yaml
@@ -9,7 +9,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/object_detection_yolox.yaml
+++ b/benchmark/config/object_detection_yolox.yaml
@@ -9,7 +9,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/object_tracking_dasiamrpn.yaml
+++ b/benchmark/config/object_tracking_dasiamrpn.yaml
@@ -7,7 +7,6 @@ Benchmark:
     files: ["throw_cup.mp4"]
   metric:
     type: "Tracking"
-    reduction: "gmean"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/palm_detection_mediapipe.yaml
+++ b/benchmark/config/palm_detection_mediapipe.yaml
@@ -9,7 +9,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/person_reid_youtureid.yaml
+++ b/benchmark/config/person_reid_youtureid.yaml
@@ -8,7 +8,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/qrcode_wechatqrcode.yaml
+++ b/benchmark/config/qrcode_wechatqrcode.yaml
@@ -6,7 +6,6 @@ Benchmark:
     files: ["opencv.png", "opencv_zoo.png"]
     sizes:
       - [100, 100]
-      - [300, 300]
   metric:
     warmup: 30
     repeat: 10

--- a/benchmark/config/qrcode_wechatqrcode.yaml
+++ b/benchmark/config/qrcode_wechatqrcode.yaml
@@ -10,7 +10,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/text_detection_db.yaml
+++ b/benchmark/config/text_detection_db.yaml
@@ -9,7 +9,6 @@ Benchmark:
   metric:
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/config/text_recognition_crnn.yaml
+++ b/benchmark/config/text_recognition_crnn.yaml
@@ -7,7 +7,6 @@ Benchmark:
   metric: # 'sizes' is omitted since this model requires input of fixed size
     warmup: 30
     repeat: 10
-    reduction: "median"
   backend: "default"
   target: "cpu"
 

--- a/benchmark/utils/metrics/base.py
+++ b/benchmark/utils/metrics/base.py
@@ -21,4 +21,4 @@ class Base(BaseMetric):
             model.infer(img)
             self._timer.stop()
 
-        return self._getResult()
+        return self._timer.getRecords()

--- a/benchmark/utils/metrics/base_metric.py
+++ b/benchmark/utils/metrics/base_metric.py
@@ -6,7 +6,6 @@ class BaseMetric:
     def __init__(self, **kwargs):
         self._warmup = kwargs.pop('warmup', 3)
         self._repeat = kwargs.pop('repeat', 10)
-        self._reduction = kwargs.pop('reduction', 'median')
 
         self._timer = Timer()
 
@@ -20,8 +19,8 @@ class BaseMetric:
         else:
             return records[mid]
 
-    def _calcGMean(self, records, drop_largest=3):
-        ''' Return the geometric mean of records after drop the first drop_largest
+    def _calcMean(self, records, drop_largest=1):
+        ''' Return the mean of records after dropping drop_largest
         '''
         l = len(records)
         if l <= drop_largest:
@@ -29,17 +28,14 @@ class BaseMetric:
         records_sorted = sorted(records, reverse=True)
         return sum(records_sorted[drop_largest:]) / (l - drop_largest)
 
-    def _getResult(self):
-        records = self._timer.getRecords()
-        if self._reduction == 'median':
-            return self._calcMedian(records)
-        elif self._reduction == 'gmean':
-            return self._calcGMean(records)
-        else:
-            raise NotImplementedError('Reduction {} is not supported'.format(self._reduction))
+    def _calcMin(self, records):
+        return min(records)
 
-    def getReduction(self):
-        return self._reduction
+    def getPerfStats(self, records):
+        mean = self._calcMean(records, int(len(records) / 10))
+        median = self._calcMedian(records)
+        minimum = self._calcMin(records)
+        return [mean, median, minimum]
 
     def forward(self, model, *args, **kwargs):
         raise NotImplementedError('Not implemented')

--- a/benchmark/utils/metrics/detection.py
+++ b/benchmark/utils/metrics/detection.py
@@ -26,4 +26,4 @@ class Detection(BaseMetric):
             model.infer(img)
             self._timer.stop()
 
-        return self._getResult()
+        return self._timer.getRecords()

--- a/benchmark/utils/metrics/recognition.py
+++ b/benchmark/utils/metrics/recognition.py
@@ -28,4 +28,4 @@ class Recognition(BaseMetric):
                 model.infer(img, None)
                 self._timer.stop()
 
-        return self._getResult()
+        return self._timer.getRecords()

--- a/benchmark/utils/metrics/tracking.py
+++ b/benchmark/utils/metrics/tracking.py
@@ -8,8 +8,8 @@ class Tracking(BaseMetric):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        if self._warmup or self._repeat:
-            print('warmup and repeat in metric for tracking do not function.')
+        # if self._warmup or self._repeat:
+        #     print('warmup and repeat in metric for tracking do not function.')
 
     def forward(self, model, *args, **kwargs):
         stream, first_frame, rois = args

--- a/benchmark/utils/metrics/tracking.py
+++ b/benchmark/utils/metrics/tracking.py
@@ -23,4 +23,4 @@ class Tracking(BaseMetric):
                 model.infer(frame)
                 self._timer.stop()
 
-        return self._getResult()
+        return self._timer.getRecords()

--- a/models/handpose_estimation_mediapipe/mp_handpose.py
+++ b/models/handpose_estimation_mediapipe/mp_handpose.py
@@ -28,8 +28,8 @@ class MPHandPose:
         return self.__class__.__name__
 
     def setBackendAndTarget(self, backendId, targetId):
-        self._backendId = backendId
-        self._targetId = targetId
+        self.backend_id = backendId
+        self.target_id = targetId
         self.model.setPreferableBackend(self.backend_id)
         self.model.setPreferableTarget(self.target_id)
 

--- a/models/image_classification_mobilenet/mobilenet.py
+++ b/models/image_classification_mobilenet/mobilenet.py
@@ -34,8 +34,8 @@ class MobileNet:
         return self.__class__.__name__
 
     def setBackendAndTarget(self, backendId, targetId):
-        self._backendId = backendId
-        self._targetId = targetId
+        self.backend_id = backendId
+        self.target_id = targetId
         self.model.setPreferableBackend(self.backend_id)
         self.model.setPreferableTarget(self.target_id)
 

--- a/models/object_detection_nanodet/nanodet.py
+++ b/models/object_detection_nanodet/nanodet.py
@@ -38,8 +38,8 @@ class NanoDet:
         return self.__class__.__name__
 
     def setBackendAndTarget(self, backendId, targetId):
-        self._backendId = backendId
-        self._targetId = targetId
+        self.backend_id = backendId
+        self.target_id = targetId
         self.net.setPreferableBackend(self.backend_id)
         self.net.setPreferableTarget(self.target_id)
 

--- a/models/object_detection_yolox/yolox.py
+++ b/models/object_detection_yolox/yolox.py
@@ -24,8 +24,8 @@ class YoloX:
         return self.__class__.__name__
 
     def setBackendAndTarget(self, backendId, targetId):
-        self._backendId = backendId
-        self._targetId = targetId
+        self.backendId = backendId
+        self.targetId = targetId
         self.net.setPreferableBackend(self.backendId)
         self.net.setPreferableTarget(self.targetId)
 


### PR DESCRIPTION
Changes:

- [x] use mean as default for benchmark results.
- [x] change result representation to something like this:
   ```shell
    $ python benchmark.py --cfg ./config/face_detection_yunet.yaml
    mean=1.17, median=1.19, min=1.06, input size=[160, 120], model: YuNet with ['face_detection_yunet_2022mar.onnx']
    mean=8.66, median=8.96, min=8.17, input size=[640, 480], model: YuNet with ['face_detection_yunet_2022mar.onnx']
    mean=1.37, median=1.48, min=1.06, input size=[160, 120], model: YuNet with ['face_detection_yunet_2022mar-act_int8-wt_int8-quantized.onnx']
    mean=10.96, median=11.17, min=8.17, input size=[640, 480], model: YuNet with ['face_detection_yunet_2022mar-act_int8-wt_int8-quantized.onnx']
   ```
- [x] add flag `--all` and `--cfg_exclude` to run all benchmarks in one command with exclusions:
   ```shell
    $ python benchmark.py --all --model_exclude license_plate_detection_lpd_yunet_2023mar_int8.onnx:human_segmentation_pphumanseg_2023mar_int8.onnx
    Benchmarking ...
    backend=cv.dnn.DNN_BACKEND_OPENCV
    target=cv.dnn.DNN_TARGET_CPU
    mean       median     min        input size   model
    0.58       0.67       0.48       [160, 120]   YuNet with ['face_detection_yunet_2022mar.onnx']
    0.82       0.81       0.48       [160, 120]   YuNet with ['face_detection_yunet_2022mar_int8.onnx']
    6.18       6.33       5.83       [150, 150]   SFace with ['face_recognition_sface_2021dec.onnx']
    7.42       7.42       5.83       [150, 150]   SFace with ['face_recognition_sface_2021dec_int8.onnx']
    3.32       3.46       2.76       [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july.onnx']
    4.27       4.22       2.76       [112, 112]   FacialExpressionRecog with ['facial_expression_recognition_mobilefacenet_2022july_int8.onnx']
    4.68       5.04       4.36       [224, 224]   MPHandPose with ['handpose_estimation_mediapipe_2023feb.onnx']
   ```
- [x] update benchmark results which uses mean as default.