### PR TITLE
update generate table script

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -57,32 +57,6 @@ python benchmark.py --all --cfg_overwrite_backend_target 1
 
 Benchmark is done with latest `opencv-python==4.7.0.72` and `opencv-contrib-python==4.7.0.72` on the following platforms. Some models are excluded because of support issues.
 
-
-| Model                                                    | Task                          | Input Size | CPU-INTEL (ms) | CPU-RPI (ms) | CPU-RV1126 (ms) | CPU-KVE2 (ms) | CPU-HSX3 (ms) | CPU-AXP (ms) | GPU-JETSON (ms) | NPU-KV3 (ms) | NPU-Ascend310 (ms) | CPU-D1 (ms) |
-| -------------------------------------------------------- | ----------------------------- | ---------- | -------------- | ------------ | --------------- | ------------- | ------------- | ------------ | --------------- | ------------ | ------------------ | ----------- |
-| [YuNet](../models/face_detection_yunet)                  | Face Detection                | 160x120    | 0.72           | 5.43         | 68.89           | 2.47          | 11.04         | 98.16        | 12.18           | 4.04         | 2.24               | 86.69       |
-| [SFace](../models/face_recognition_sface)                | Face Recognition              | 112x112    | 6.04           | 78.83        | 1550.71         | 33.79         | 140.83        | 2093.12      | 24.88           | 46.25        | 2.66               | ---         |
-| [FER](../models/facial_expression_recognition/)          | Facial Expression Recognition | 112x112    | 3.16           | 32.53        | 604.36          | 15.99         | 64.96         | 811.32       | 31.07           | 29.80        | 2.19               | ---         |
-| [LPD-YuNet](../models/license_plate_detection_yunet/)    | License Plate Detection       | 320x240    | 8.63           | 167.70       | 3222.92         | 57.57         | 283.75        | 4300.13      | 56.12           | 29.53        | 7.63               | ---         |
-| [YOLOX](../models/object_detection_yolox/)               | Object Detection              | 640x640    | 141.20         | 1805.87      | 38359.93        | 577.93        | 2749.22       | 49994.75     | 388.95          | 420.98       | 28.59              | ---         |
-| [NanoDet](../models/object_detection_nanodet/)           | Object Detection              | 416x416    | 66.03          | 225.10       | 2303.55         | 118.38        | 408.16        | 3360.20      | 64.94           | 116.64       | 20.62              | ---         |
-| [DB-IC15](../models/text_detection_db) (EN)              | Text Detection                | 640x480    | 71.03          | 1862.75      | 49065.03        | 394.77        | 1908.87       | 65681.91     | 208.41          | ---          | 17.15              | ---         |
-| [DB-TD500](../models/text_detection_db) (EN&CN)          | Text Detection                | 640x480    | 72.31          | 1878.45      | 49052.24        | 392.52        | 1922.34       | 65630.56     | 210.51          | ---          | 17.95              | ---         |
-| [CRNN-EN](../models/text_recognition_crnn)               | Text Recognition              | 100x32     | 20.16          | 278.11       | 2230.12         | 77.51         | 464.58        | 3277.07      | 196.15          | 125.30       | ---                | ---         |
-| [CRNN-CN](../models/text_recognition_crnn)               | Text Recognition              | 100x32     | 23.07          | 297.48       | 2244.03         | 82.93         | 495.94        | 3330.69      | 239.76          | 166.79       | ---                | ---         |
-| [PP-ResNet](../models/image_classification_ppresnet)     | Image Classification          | 224x224    | 34.71          | 463.93       | 11793.09        | 178.87        | 759.81        | 15753.56     | 98.64           | 75.45        | 6.99               | ---         |
-| [MobileNet-V1](../models/image_classification_mobilenet) | Image Classification          | 224x224    | 5.90           | 72.33        | 1546.16         | 32.78         | 140.60        | 2091.13      | 33.18           | 145.66\*     | 5.15               | ---         |
-| [MobileNet-V2](../models/image_classification_mobilenet) | Image Classification          | 224x224    | 5.97           | 66.56        | 1166.56         | 28.38         | 122.53        | 1583.25      | 31.92           | 146.31\*     | 5.41               | ---         |
-| [PP-HumanSeg](../models/human_segmentation_pphumanseg)   | Human Segmentation            | 192x192    | 8.81           | 73.13        | 1610.78         | 34.58         | 144.23        | 2157.86      | 67.97           | 74.77        | 6.94               | ---         |
-| [WeChatQRCode](../models/qrcode_wechatqrcode)            | QR Code Detection and Parsing | 100x100    | 1.29           | 5.71         | ---             | ---           | ---           | ---          | ---             | ---          | ---                | ---         |
-| [DaSiamRPN](../models/object_tracking_dasiamrpn)         | Object Tracking               | 1280x720   | 29.05          | 712.94       | 14738.64        | 152.78        | 929.63        | 19800.14     | 76.82           | ---          | ---                | ---         |
-| [YoutuReID](../models/person_reid_youtureid)             | Person Re-Identification      | 128x256    | 30.39          | 625.56       | 11117.07        | 195.67        | 898.23        | 14886.02     | 90.07           | 44.61        | 5.58               | ---         |
-| [MP-PalmDet](../models/palm_detection_mediapipe)         | Palm Detection                | 192x192    | 6.29           | 86.83        | 872.09          | 38.03         | 142.23        | 1191.81      | 83.20           | 33.81        | 5.17               | ---         |
-| [MP-HandPose](../models/handpose_estimation_mediapipe)   | Hand Pose Estimation          | 224x224    | 4.68           | 43.57        | 460.56          | 20.27         | 80.67         | 636.22       | 40.10           | 19.47        | 6.27               | ---         |
-| [MP-PersonDet](../models/person_detection_mediapipe)     | Person Detection              | 224x224    | 13.88          | 98.52        | 1326.56         | 46.07         | 191.41        | 1835.97      | 56.69           | ---          | 16.45              | ---         |
-
-\*: Models are quantized in per-channel mode, which run slower than per-tensor quantized models on NPU.
-
 ### Intel 12700K
 
 Specs: [details](https://www.intel.com/content/www/us/en/products/sku/134594/intel-core-i712700k-processor-25m-cache-up-to-5-00-ghz/specifications.html)

--- a/benchmark/color_table.svg
+++ b/benchmark/color_table.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1435.57425pt" height="556.178824pt" viewBox="0 0 1435.57425 556.178824" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1546.489312pt" height="600.632471pt" viewBox="0 0 1546.489312 600.632471" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -15,3041 +15,3718 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 556.178824 
-L 1435.57425 556.178824 
-L 1435.57425 0 
+   <path d="M 0 600.632471 
+L 1546.489312 600.632471 
+L 1546.489312 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
-   <g clip-path="url(#pba7c3a785f)">
+   <g clip-path="url(#pdeedcc1849)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAwcAAAATCAYAAADF93FfAAABT0lEQVR4nO3XQU7DMBAF0J/0UFyJ++9rs7HAKTFylKYI8d5qNBqPDS1Cf8n7W02zLPm0rMvz6+WCnRN3XXXH2t1x6/q37uptf1CvGfQvnj/z/hPzaz/f1X3/8fzMman5wbvH+580P/gMjv9cfb3u9zMxM7PnxM6r9h6dWdLV/dlRf3B205/Z8wf3f1PLV13Kfn+mfuXZX3pnLYM9pQ76F8yc3vW6t9bNTFffazdTdvvbmf1+v7Pe999WB/OvfMNmfnJXue//HuvgTTMzZerssXvLzNsO3ju1c1APv64n6mTyT+JZ9cV31W7/D/8ZAACA/0Q4AAAAkggHAABAIxwAAABJhAMAAKARDgAAgCTCAQAA0AgHAABAEuEAAABohAMAACCJcAAAADTCAQAAkEQ4AAAAGuEAAABIIhwAAACNcAAAACQRDgAAgEY4AAAAkiQf4IEj/7SBZSAAAAAASUVORK5CYII=" id="image084f7b510c" transform="scale(1 -1) translate(0 -13.68)" x="378" y="0.635294" width="558" height="13.68"/>
+iVBORw0KGgoAAAANSUhEUgAAAwgAAAATCAYAAAA0/CrSAAABSklEQVR4nO3XS27DMAwFQMk5VK/U++8jdVOwNGC2ChIbLTqzIgiKVn4IXm/vb7N96r2FvvXX1/2Enam++nlb2n9L/Vu60r5f1Fsr+ifPP3P/Yn71TP7Y8vl9/4T54t71/hfNF5/B468r19thv7XWtvbz3MquXf1XdqaZ3lKdz1b94uyuv7DnimecsX9njq96jOP+Sn3l2Tx/8V3nKPaMWfR/28wJ+7+Zm7tdqb7PNDMO+/uZ437eOe/H95vF/JV3eHTPuB+/h7Paszg3iv4sXsPSzoWZsl88d2lnUZdf2WfqhZ/E1c97pp5pf/HPAAAA/EcCAgAAEAQEAAAgCAgAAEAQEAAAgCAgAAAAQUAAAACCgAAAAAQBAQAACAICAAAQBAQAACAICAAAQBAQAACAICAAAABBQAAAAIKAAAAABAEBAAAIAgIAABA+AEq1I/9cZQrJAAAAAElFTkSuQmCC" id="imaged38e91eac8" transform="scale(1 -1) translate(0 -13.68)" x="544.784516" y="0.635294" width="558.72" height="13.68"/>
    </g>
    <g id="text_1">
-    <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="372.42" y="9.557665" transform="rotate(-0 372.42 9.557665)">Faster</text>
+    <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="539.204516" y="9.557665" transform="rotate(-0 539.204516 9.557665)">Faster</text>
    </g>
    <g id="text_2">
-    <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="941.58" y="9.557665" transform="rotate(-0 941.58 9.557665)">Slower</text>
+    <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1108.364516" y="9.557665" transform="rotate(-0 1108.364516 9.557665)">Slower</text>
    </g>
   </g>
   <g id="axes_2">
    <g id="table_1">
     <g id="patch_2">
-     <path d="M 0 52.698353 
-L 128.297812 52.698353 
+     <a>
+      <path d="M 0 81.498353 
+L 128.297812 81.498353 
 L 128.297812 28.698353 
 L 0 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_3">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="43.733665" transform="rotate(-0 12.829781 43.733665)">Model</text>
+     <a>
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="64.148906" y="58.133665" transform="rotate(-0 64.148906 58.133665)">Model</text>
+     </a>
     </g>
     <g id="patch_3">
-     <path d="M 128.297812 52.698353 
-L 335.566687 52.698353 
-L 335.566687 28.698353 
+     <a>
+      <path d="M 128.297812 81.498353 
+L 335.566688 81.498353 
+L 335.566688 28.698353 
 L 128.297812 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_4">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="43.733665" transform="rotate(-0 149.0247 43.733665)">Task</text>
+     <a>
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="231.93225" y="58.133665" transform="rotate(-0 231.93225 58.133665)">Task</text>
+     </a>
     </g>
     <g id="patch_4">
-     <path d="M 335.566687 52.698353 
-L 402.168937 52.698353 
-L 402.168937 28.698353 
-L 335.566687 28.698353 
+     <a>
+      <path d="M 335.566688 81.498353 
+L 410.291063 81.498353 
+L 410.291063 28.698353 
+L 335.566688 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_5">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="43.733665" transform="rotate(-0 342.226912 43.733665)">Input Size</text>
+     <a>
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="372.928875" y="58.133665" transform="rotate(-0 372.928875 58.133665)">Input Size</text>
+     </a>
     </g>
     <g id="patch_5">
-     <path d="M 402.168937 52.698353 
-L 505.524937 52.698353 
-L 505.524937 28.698353 
-L 402.168937 28.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#intel-12700k">
+      <path d="M 410.291063 81.498353 
+L 466.440562 81.498353 
+L 466.440562 28.698353 
+L 410.291063 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_6">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="43.733665" transform="rotate(-0 412.504537 43.733665)">CPU-INTEL (ms)</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#intel-12700k">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(424.159484 43.308587)">Intel</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#intel-12700k">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(414.970188 58.133665)">12700K</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#intel-12700k">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(425.831828 72.958744)">CPU</text>
+     </a>
     </g>
     <g id="patch_6">
-     <path d="M 505.524937 52.698353 
-L 592.378875 52.698353 
-L 592.378875 28.698353 
-L 505.524937 28.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#rasberry-pi-4b">
+      <path d="M 466.440562 81.498353 
+L 576.029438 81.498353 
+L 576.029438 28.698353 
+L 466.440562 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_7">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="43.733665" transform="rotate(-0 514.210331 43.733665)">CPU-RPI (ms)</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#rasberry-pi-4b">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(475.572969 43.265619)">Rasberry Pi 4B</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#rasberry-pi-4b">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(492.225937 58.176634)">BCM2711</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#rasberry-pi-4b">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(508.701016 73.001712)">CPU</text>
+     </a>
     </g>
     <g id="patch_7">
-     <path d="M 592.378875 52.698353 
-L 709.27725 52.698353 
-L 709.27725 28.698353 
-L 592.378875 28.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#toybrick-rv1126">
+      <path d="M 576.029438 81.498353 
+L 639.014063 81.498353 
+L 639.014063 28.698353 
+L 576.029438 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_8">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="43.733665" transform="rotate(-0 604.068712 43.733665)">CPU-RV1126 (ms)</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#toybrick-rv1126">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(581.682063 43.265619)">Toybrick</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#toybrick-rv1126">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(583.723078 58.176634)">RV1126</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#toybrick-rv1126">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(594.987766 73.001712)">CPU</text>
+     </a>
     </g>
     <g id="patch_8">
-     <path d="M 709.27725 52.698353 
-L 809.53125 52.698353 
-L 809.53125 28.698353 
-L 709.27725 28.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-edge2-(with-rk3588)">
+      <path d="M 639.014063 81.498353 
+L 744.40575 81.498353 
+L 744.40575 28.698353 
+L 639.014063 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_9">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="43.733665" transform="rotate(-0 719.30265 43.733665)">CPU-KVE2 (ms)</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-edge2-(with-rk3588)">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(647.796703 43.265619)">Khadas Edge2</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-edge2-(with-rk3588)">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(663.945219 58.176634)">RK3588S</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-edge2-(with-rk3588)">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(679.175922 73.001712)">CPU</text>
+     </a>
     </g>
     <g id="patch_9">
-     <path d="M 809.53125 52.698353 
-L 911.107312 52.698353 
-L 911.107312 28.698353 
-L 809.53125 28.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#horizon-sunrise-x3-pi">
+      <path d="M 744.40575 81.498353 
+L 881.238187 81.498353 
+L 881.238187 28.698353 
+L 744.40575 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_10">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="43.733665" transform="rotate(-0 819.688856 43.733665)">CPU-HSX3 (ms)</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#horizon-sunrise-x3-pi">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(755.808453 43.308587)">Horizon Sunrise Pi</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#horizon-sunrise-x3-pi">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(804.755016 58.133665)">X3</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#horizon-sunrise-x3-pi">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(800.287984 72.958744)">CPU</text>
+     </a>
     </g>
     <g id="patch_10">
-     <path d="M 911.107312 52.698353 
-L 1002.669937 52.698353 
-L 1002.669937 28.698353 
-L 911.107312 28.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#maix-iii-ax-pi">
+      <path d="M 881.238187 81.498353 
+L 982.407937 81.498353 
+L 982.407937 28.698353 
+L 881.238187 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_11">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="43.733665" transform="rotate(-0 920.263575 43.733665)">CPU-AXP (ms)</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#maix-iii-ax-pi">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(889.669 43.308587)">MAIX-III AX-Pi</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#maix-iii-ax-pi">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(907.589547 58.133665)">AX620A</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#maix-iii-ax-pi">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(919.289078 72.958744)">CPU</text>
+     </a>
     </g>
     <g id="patch_11">
-     <path d="M 1002.669937 52.698353 
-L 1119.195 52.698353 
-L 1119.195 28.698353 
-L 1002.669937 28.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#jetson-nano-b01">
+      <path d="M 982.407937 81.498353 
+L 1071.918375 81.498353 
+L 1071.918375 28.698353 
+L 982.407937 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_12">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="43.733665" transform="rotate(-0 1014.322444 43.733665)">GPU-JETSON (ms)</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#jetson-nano-b01">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(989.867141 43.308587)">Jetson Nano</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#jetson-nano-b01">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1015.317531 58.133665)">B01</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#jetson-nano-b01">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1014.629172 72.958744)">CPU</text>
+     </a>
     </g>
     <g id="patch_12">
-     <path d="M 1119.195 52.698353 
-L 1211.766187 52.698353 
-L 1211.766187 28.698353 
-L 1119.195 28.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-vim3">
+      <path d="M 1071.918375 81.498353 
+L 1168.705313 81.498353 
+L 1168.705313 28.698353 
+L 1071.918375 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_13">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="43.733665" transform="rotate(-0 1128.452119 43.733665)">NPU-KV3 (ms)</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-vim3">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1079.983953 43.308587)">Khadas VIM3</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-vim3">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1100.009109 58.133665)">A311D</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-vim3">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1107.777859 72.958744)">CPU</text>
+     </a>
     </g>
     <g id="patch_13">
-     <path d="M 1211.766187 52.698353 
-L 1351.182937 52.698353 
-L 1351.182937 28.698353 
-L 1211.766187 28.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#atlas-200-dk">
+      <path d="M 1168.705313 81.498353 
+L 1264.448625 81.498353 
+L 1264.448625 28.698353 
+L 1168.705313 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_14">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="43.733665" transform="rotate(-0 1225.707862 43.733665)">NPU-Ascend310 (ms)</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#atlas-200-dk">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1176.683922 43.308587)">Atlas 200 DK</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#atlas-200-dk">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1180.808922 58.133665)">Ascend 310</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#atlas-200-dk">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1204.042984 72.958744)">CPU</text>
+     </a>
     </g>
     <g id="patch_14">
-     <path d="M 1351.182937 52.698353 
-L 1435.57425 52.698353 
-L 1435.57425 28.698353 
-L 1351.182937 28.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#jetson-nano-b01">
+      <path d="M 1264.448625 81.498353 
+L 1353.959063 81.498353 
+L 1353.959063 28.698353 
+L 1264.448625 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_15">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="43.733665" transform="rotate(-0 1359.622069 43.733665)">CPU-D1 (ms)</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#jetson-nano-b01">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1271.907828 43.308587)">Jetson Nano</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#jetson-nano-b01">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1297.358219 58.133665)">B01</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#jetson-nano-b01">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1296.192047 72.958744)">GPU</text>
+     </a>
     </g>
     <g id="patch_15">
-     <path d="M 0 76.698353 
-L 128.297812 76.698353 
-L 128.297812 52.698353 
-L 0 52.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-vim3">
+      <path d="M 1353.959063 81.498353 
+L 1450.746 81.498353 
+L 1450.746 28.698353 
+L 1353.959063 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_16">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="67.733665" transform="rotate(-0 12.829781 67.733665)">YuNet</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-vim3">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1362.024641 43.308587)">Khadas VIM3</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-vim3">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1382.049797 58.133665)">A311D</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#khadas-vim3">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1389.252219 72.958744)">NPU</text>
+     </a>
     </g>
     <g id="patch_16">
-     <path d="M 128.297812 76.698353 
-L 335.566687 76.698353 
-L 335.566687 52.698353 
-L 128.297812 52.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#atlas-200-dk">
+      <path d="M 1450.746 81.498353 
+L 1546.489312 81.498353 
+L 1546.489312 28.698353 
+L 1450.746 28.698353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_17">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="67.733665" transform="rotate(-0 149.0247 67.733665)">Face Detection</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#atlas-200-dk">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1458.724609 43.308587)">Atlas 200 DK</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#atlas-200-dk">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1462.849609 58.133665)">Ascend 310</text>
+     </a>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/benchmark#atlas-200-dk">
+      <text style="font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif" transform="translate(1485.517344 72.958744)">NPU</text>
+     </a>
     </g>
     <g id="patch_17">
-     <path d="M 335.566687 76.698353 
-L 402.168937 76.698353 
-L 402.168937 52.698353 
-L 335.566687 52.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/face_detection_yunet">
+      <path d="M 0 105.498353 
+L 128.297812 105.498353 
+L 128.297812 81.498353 
+L 0 81.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_18">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="67.733665" transform="rotate(-0 342.226912 67.733665)">160x120</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/face_detection_yunet">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="96.533665" transform="rotate(-0 12.829781 96.533665)">YuNet</text>
+     </a>
     </g>
     <g id="patch_18">
-     <path d="M 402.168937 76.698353 
-L 505.524937 76.698353 
-L 505.524937 52.698353 
-L 402.168937 52.698353 
+     <path d="M 128.297812 105.498353 
+L 335.566688 105.498353 
+L 335.566688 81.498353 
+L 128.297812 81.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_19">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="67.733665" transform="rotate(-0 412.504537 67.733665)">0.72</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="96.533665" transform="rotate(-0 149.0247 96.533665)">Face Detection</text>
     </g>
     <g id="patch_19">
-     <path d="M 505.524937 76.698353 
-L 592.378875 76.698353 
-L 592.378875 52.698353 
-L 505.524937 52.698353 
+     <path d="M 335.566688 105.498353 
+L 410.291063 105.498353 
+L 410.291063 81.498353 
+L 335.566688 81.498353 
 z
-" style="fill: #0c7f43; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_20">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="67.733665" transform="rotate(-0 514.210331 67.733665)">5.43</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="96.533665" transform="rotate(-0 343.039125 96.533665)">160x120</text>
     </g>
     <g id="patch_20">
-     <path d="M 592.378875 76.698353 
-L 709.27725 76.698353 
-L 709.27725 52.698353 
-L 592.378875 52.698353 
+     <path d="M 410.291063 105.498353 
+L 466.440562 105.498353 
+L 466.440562 81.498353 
+L 410.291063 81.498353 
 z
-" style="fill: #fdad60; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_21">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="67.733665" transform="rotate(-0 604.068712 67.733665)">68.89</text>
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="96.533665" transform="rotate(-0 415.906013 96.533665)">0.58</text>
     </g>
     <g id="patch_21">
-     <path d="M 709.27725 76.698353 
-L 809.53125 76.698353 
-L 809.53125 52.698353 
-L 709.27725 52.698353 
+     <path d="M 466.440562 105.498353 
+L 576.029438 105.498353 
+L 576.029438 81.498353 
+L 466.440562 81.498353 
 z
-" style="fill: #04703b; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #addc6f; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_22">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="67.733665" transform="rotate(-0 719.30265 67.733665)">2.47</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="96.533665" transform="rotate(-0 477.39945 96.533665)">5.45</text>
     </g>
     <g id="patch_22">
-     <path d="M 809.53125 76.698353 
-L 911.107312 76.698353 
-L 911.107312 52.698353 
-L 809.53125 52.698353 
+     <path d="M 576.029438 105.498353 
+L 639.014063 105.498353 
+L 639.014063 81.498353 
+L 576.029438 81.498353 
 z
-" style="fill: #1e9a51; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_23">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="67.733665" transform="rotate(-0 819.688856 67.733665)">11.04</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="96.533665" transform="rotate(-0 582.3279 96.533665)">68.89</text>
     </g>
     <g id="patch_23">
-     <path d="M 911.107312 76.698353 
-L 1002.669937 76.698353 
-L 1002.669937 52.698353 
-L 911.107312 52.698353 
+     <path d="M 639.014063 105.498353 
+L 744.40575 105.498353 
+L 744.40575 81.498353 
+L 639.014063 81.498353 
 z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #63bc62; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_24">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="67.733665" transform="rotate(-0 920.263575 67.733665)">98.16</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="96.533665" transform="rotate(-0 649.553231 96.533665)">2.47</text>
     </g>
     <g id="patch_24">
-     <path d="M 1002.669937 76.698353 
-L 1119.195 76.698353 
-L 1119.195 52.698353 
-L 1002.669937 52.698353 
+     <path d="M 744.40575 105.498353 
+L 881.238187 105.498353 
+L 881.238187 81.498353 
+L 744.40575 81.498353 
 z
-" style="fill: #279f53; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #eff8aa; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="67.733665" transform="rotate(-0 1014.322444 67.733665)">12.18</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="96.533665" transform="rotate(-0 758.088994 96.533665)">11.04</text>
     </g>
     <g id="patch_25">
-     <path d="M 1119.195 76.698353 
-L 1211.766187 76.698353 
-L 1211.766187 52.698353 
-L 1119.195 52.698353 
-z
-" style="fill: #08773f; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_26">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="67.733665" transform="rotate(-0 1128.452119 67.733665)">4.04</text>
-    </g>
-    <g id="patch_26">
-     <path d="M 1211.766187 76.698353 
-L 1351.182937 76.698353 
-L 1351.182937 52.698353 
-L 1211.766187 52.698353 
-z
-" style="fill: #036e3a; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_27">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="67.733665" transform="rotate(-0 1225.707862 67.733665)">2.24</text>
-    </g>
-    <g id="patch_27">
-     <path d="M 1351.182937 76.698353 
-L 1435.57425 76.698353 
-L 1435.57425 52.698353 
-L 1351.182937 52.698353 
-z
-" style="fill: #dc3b2c; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_28">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="67.733665" transform="rotate(-0 1359.622069 67.733665)">86.69</text>
-    </g>
-    <g id="patch_28">
-     <path d="M 0 100.698353 
-L 128.297812 100.698353 
-L 128.297812 76.698353 
-L 0 76.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_29">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="91.733665" transform="rotate(-0 12.829781 91.733665)">SFace</text>
-    </g>
-    <g id="patch_29">
-     <path d="M 128.297812 100.698353 
-L 335.566687 100.698353 
-L 335.566687 76.698353 
-L 128.297812 76.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_30">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="91.733665" transform="rotate(-0 149.0247 91.733665)">Face Recognition</text>
-    </g>
-    <g id="patch_30">
-     <path d="M 335.566687 100.698353 
-L 402.168937 100.698353 
-L 402.168937 76.698353 
-L 335.566687 76.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_31">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="91.733665" transform="rotate(-0 342.226912 91.733665)">112x112</text>
-    </g>
-    <g id="patch_31">
-     <path d="M 402.168937 100.698353 
-L 505.524937 100.698353 
-L 505.524937 76.698353 
-L 402.168937 76.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_32">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="91.733665" transform="rotate(-0 412.504537 91.733665)">6.04</text>
-    </g>
-    <g id="patch_32">
-     <path d="M 505.524937 100.698353 
-L 592.378875 100.698353 
-L 592.378875 76.698353 
-L 505.524937 76.698353 
-z
-" style="fill: #097940; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_33">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="91.733665" transform="rotate(-0 514.210331 91.733665)">78.83</text>
-    </g>
-    <g id="patch_33">
-     <path d="M 592.378875 100.698353 
-L 709.27725 100.698353 
-L 709.27725 76.698353 
-L 592.378875 76.698353 
-z
-" style="fill: #f99355; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_34">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="91.733665" transform="rotate(-0 604.068712 91.733665)">1550.71</text>
-    </g>
-    <g id="patch_34">
-     <path d="M 709.27725 100.698353 
-L 809.53125 100.698353 
-L 809.53125 76.698353 
-L 709.27725 76.698353 
-z
-" style="fill: #036e3a; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_35">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="91.733665" transform="rotate(-0 719.30265 91.733665)">33.79</text>
-    </g>
-    <g id="patch_35">
-     <path d="M 809.53125 100.698353 
-L 911.107312 100.698353 
-L 911.107312 76.698353 
-L 809.53125 76.698353 
-z
-" style="fill: #108647; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_36">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="91.733665" transform="rotate(-0 819.688856 91.733665)">140.83</text>
-    </g>
-    <g id="patch_36">
-     <path d="M 911.107312 100.698353 
-L 1002.669937 100.698353 
-L 1002.669937 76.698353 
-L 911.107312 76.698353 
+     <path d="M 881.238187 105.498353 
+L 982.407937 105.498353 
+L 982.407937 81.498353 
+L 881.238187 81.498353 
 z
 " style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_26">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="96.533665" transform="rotate(-0 891.355163 96.533665)">98.16</text>
+    </g>
+    <g id="patch_26">
+     <path d="M 982.407937 105.498353 
+L 1071.918375 105.498353 
+L 1071.918375 81.498353 
+L 982.407937 81.498353 
+z
+" style="fill: #abdb6d; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_27">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="96.533665" transform="rotate(-0 991.358981 96.533665)">5.37</text>
+    </g>
+    <g id="patch_27">
+     <path d="M 1071.918375 105.498353 
+L 1168.705313 105.498353 
+L 1168.705313 81.498353 
+L 1071.918375 81.498353 
+z
+" style="fill: #a2d76a; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_28">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="96.533665" transform="rotate(-0 1081.597069 96.533665)">4.93</text>
+    </g>
+    <g id="patch_28">
+     <path d="M 1168.705313 105.498353 
+L 1264.448625 105.498353 
+L 1264.448625 81.498353 
+L 1168.705313 81.498353 
+z
+" style="fill: #d3ec87; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_29">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="96.533665" transform="rotate(-0 1178.279644 96.533665)">8.02</text>
+    </g>
+    <g id="patch_29">
+     <path d="M 1264.448625 105.498353 
+L 1353.959063 105.498353 
+L 1353.959063 81.498353 
+L 1264.448625 81.498353 
+z
+" style="fill: #f1f9ac; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_30">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="96.533665" transform="rotate(-0 1273.399669 96.533665)">11.22</text>
+    </g>
+    <g id="patch_30">
+     <path d="M 1353.959063 105.498353 
+L 1450.746 105.498353 
+L 1450.746 81.498353 
+L 1353.959063 81.498353 
+z
+" style="fill: #b1de71; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_31">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="96.533665" transform="rotate(-0 1363.637756 96.533665)">5.67</text>
+    </g>
+    <g id="patch_31">
+     <path d="M 1450.746 105.498353 
+L 1546.489312 105.498353 
+L 1546.489312 81.498353 
+L 1450.746 81.498353 
+z
+" style="fill: #57b65f; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_32">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="96.533665" transform="rotate(-0 1460.320331 96.533665)">2.24</text>
+    </g>
+    <g id="patch_32">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/face_recognition_sface">
+      <path d="M 0 129.498353 
+L 128.297812 129.498353 
+L 128.297812 105.498353 
+L 0 105.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
+    <g id="text_33">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/face_recognition_sface">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="120.533665" transform="rotate(-0 12.829781 120.533665)">SFace</text>
+     </a>
+    </g>
+    <g id="patch_33">
+     <path d="M 128.297812 129.498353 
+L 335.566688 129.498353 
+L 335.566688 105.498353 
+L 128.297812 105.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_34">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="120.533665" transform="rotate(-0 149.0247 120.533665)">Face Recognition</text>
+    </g>
+    <g id="patch_34">
+     <path d="M 335.566688 129.498353 
+L 410.291063 129.498353 
+L 410.291063 105.498353 
+L 335.566688 105.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_35">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="120.533665" transform="rotate(-0 343.039125 120.533665)">112x112</text>
+    </g>
+    <g id="patch_35">
+     <path d="M 410.291063 129.498353 
+L 466.440562 129.498353 
+L 466.440562 105.498353 
+L 410.291063 105.498353 
+z
+" style="fill: #33a456; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_36">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="120.533665" transform="rotate(-0 415.906013 120.533665)">6.18</text>
+    </g>
+    <g id="patch_36">
+     <path d="M 466.440562 129.498353 
+L 576.029438 129.498353 
+L 576.029438 105.498353 
+L 466.440562 105.498353 
+z
+" style="fill: #fed683; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
     <g id="text_37">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="91.733665" transform="rotate(-0 920.263575 91.733665)">2093.12</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="120.533665" transform="rotate(-0 477.39945 120.533665)">78.04</text>
     </g>
     <g id="patch_37">
-     <path d="M 1002.669937 100.698353 
-L 1119.195 100.698353 
-L 1119.195 76.698353 
-L 1002.669937 76.698353 
+     <path d="M 576.029438 129.498353 
+L 639.014063 129.498353 
+L 639.014063 105.498353 
+L 576.029438 105.498353 
 z
-" style="fill: #026c39; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_38">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="91.733665" transform="rotate(-0 1014.322444 91.733665)">24.88</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="120.533665" transform="rotate(-0 582.3279 120.533665)">1550.71</text>
     </g>
     <g id="patch_38">
-     <path d="M 1119.195 100.698353 
-L 1211.766187 100.698353 
-L 1211.766187 76.698353 
-L 1119.195 76.698353 
+     <path d="M 639.014063 129.498353 
+L 744.40575 129.498353 
+L 744.40575 105.498353 
+L 639.014063 105.498353 
 z
-" style="fill: #05713c; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #d7ee8a; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_39">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="91.733665" transform="rotate(-0 1128.452119 91.733665)">46.25</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="120.533665" transform="rotate(-0 649.553231 120.533665)">33.79</text>
     </g>
     <g id="patch_39">
-     <path d="M 1211.766187 100.698353 
-L 1351.182937 100.698353 
-L 1351.182937 76.698353 
-L 1211.766187 76.698353 
+     <path d="M 744.40575 129.498353 
+L 881.238187 129.498353 
+L 881.238187 105.498353 
+L 744.40575 105.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #e95538; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_40">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="91.733665" transform="rotate(-0 1225.707862 91.733665)">2.66</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="120.533665" transform="rotate(-0 758.088994 120.533665)">140.83</text>
     </g>
     <g id="patch_40">
-     <path d="M 1351.182937 100.698353 
-L 1435.57425 100.698353 
-L 1435.57425 76.698353 
-L 1351.182937 76.698353 
+     <path d="M 881.238187 129.498353 
+L 982.407937 129.498353 
+L 982.407937 105.498353 
+L 881.238187 105.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_41">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="91.733665" transform="rotate(-0 1359.622069 91.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="120.533665" transform="rotate(-0 891.355163 120.533665)">2093.12</text>
     </g>
     <g id="patch_41">
-     <path d="M 0 124.698353 
-L 128.297812 124.698353 
-L 128.297812 100.698353 
-L 0 100.698353 
+     <path d="M 982.407937 129.498353 
+L 1071.918375 129.498353 
+L 1071.918375 105.498353 
+L 982.407937 105.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #feeb9d; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_42">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="115.733665" transform="rotate(-0 12.829781 115.733665)">FER</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="120.533665" transform="rotate(-0 991.358981 120.533665)">65.14</text>
     </g>
     <g id="patch_42">
-     <path d="M 128.297812 124.698353 
-L 335.566687 124.698353 
-L 335.566687 100.698353 
-L 128.297812 100.698353 
+     <path d="M 1071.918375 129.498353 
+L 1168.705313 129.498353 
+L 1168.705313 105.498353 
+L 1071.918375 105.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #fff2aa; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_43">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="115.733665" transform="rotate(-0 149.0247 115.733665)">Facial Expression Recognition</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="120.533665" transform="rotate(-0 1081.597069 120.533665)">60.02</text>
     </g>
     <g id="patch_43">
-     <path d="M 335.566687 124.698353 
-L 402.168937 124.698353 
-L 402.168937 100.698353 
-L 335.566687 100.698353 
+     <path d="M 1168.705313 129.498353 
+L 1264.448625 129.498353 
+L 1264.448625 105.498353 
+L 1168.705313 105.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #fba35c; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_44">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="115.733665" transform="rotate(-0 342.226912 115.733665)">112x112</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="120.533665" transform="rotate(-0 1178.279644 120.533665)">104.51</text>
     </g>
     <g id="patch_44">
-     <path d="M 402.168937 124.698353 
-L 505.524937 124.698353 
-L 505.524937 100.698353 
-L 402.168937 100.698353 
+     <path d="M 1264.448625 129.498353 
+L 1353.959063 129.498353 
+L 1353.959063 105.498353 
+L 1264.448625 105.498353 
+z
+" style="fill: #b7e075; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_45">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="120.533665" transform="rotate(-0 1273.399669 120.533665)">24.60</text>
+    </g>
+    <g id="patch_45">
+     <path d="M 1353.959063 129.498353 
+L 1450.746 129.498353 
+L 1450.746 105.498353 
+L 1353.959063 105.498353 
+z
+" style="fill: #fed884; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_46">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="120.533665" transform="rotate(-0 1363.637756 120.533665)">76.97</text>
+    </g>
+    <g id="patch_46">
+     <path d="M 1450.746 129.498353 
+L 1546.489312 129.498353 
+L 1546.489312 105.498353 
+L 1450.746 105.498353 
 z
 " style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_45">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="115.733665" transform="rotate(-0 412.504537 115.733665)">3.16</text>
-    </g>
-    <g id="patch_45">
-     <path d="M 505.524937 124.698353 
-L 592.378875 124.698353 
-L 592.378875 100.698353 
-L 505.524937 100.698353 
-z
-" style="fill: #097940; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_46">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="115.733665" transform="rotate(-0 514.210331 115.733665)">32.53</text>
-    </g>
-    <g id="patch_46">
-     <path d="M 592.378875 124.698353 
-L 709.27725 124.698353 
-L 709.27725 100.698353 
-L 592.378875 100.698353 
-z
-" style="fill: #f99153; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
     <g id="text_47">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="115.733665" transform="rotate(-0 604.068712 115.733665)">604.36</text>
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="120.533665" transform="rotate(-0 1460.320331 120.533665)">2.66</text>
     </g>
     <g id="patch_47">
-     <path d="M 709.27725 124.698353 
-L 809.53125 124.698353 
-L 809.53125 100.698353 
-L 709.27725 100.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/facial_expression_recognition">
+      <path d="M 0 153.498353 
+L 128.297812 153.498353 
+L 128.297812 129.498353 
+L 0 129.498353 
 z
-" style="fill: #04703b; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_48">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="115.733665" transform="rotate(-0 719.30265 115.733665)">15.99</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/facial_expression_recognition">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="144.533665" transform="rotate(-0 12.829781 144.533665)">FER</text>
+     </a>
     </g>
     <g id="patch_48">
-     <path d="M 809.53125 124.698353 
-L 911.107312 124.698353 
-L 911.107312 100.698353 
-L 809.53125 100.698353 
+     <path d="M 128.297812 153.498353 
+L 335.566688 153.498353 
+L 335.566688 129.498353 
+L 128.297812 129.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_49">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="144.533665" transform="rotate(-0 149.0247 144.533665)">Face Expression Recognition</text>
+    </g>
+    <g id="patch_49">
+     <path d="M 335.566688 153.498353 
+L 410.291063 153.498353 
+L 410.291063 129.498353 
+L 335.566688 129.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_50">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="144.533665" transform="rotate(-0 343.039125 144.533665)">112x112</text>
+    </g>
+    <g id="patch_50">
+     <path d="M 410.291063 153.498353 
+L 466.440562 153.498353 
+L 466.440562 129.498353 
+L 410.291063 129.498353 
 z
 " style="fill: #138c4a; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_49">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="115.733665" transform="rotate(-0 819.688856 115.733665)">64.96</text>
-    </g>
-    <g id="patch_49">
-     <path d="M 911.107312 124.698353 
-L 1002.669937 124.698353 
-L 1002.669937 100.698353 
-L 911.107312 100.698353 
-z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_50">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="115.733665" transform="rotate(-0 920.263575 115.733665)">811.32</text>
-    </g>
-    <g id="patch_50">
-     <path d="M 1002.669937 124.698353 
-L 1119.195 124.698353 
-L 1119.195 100.698353 
-L 1002.669937 100.698353 
-z
-" style="fill: #097940; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
     <g id="text_51">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="115.733665" transform="rotate(-0 1014.322444 115.733665)">31.07</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="144.533665" transform="rotate(-0 415.906013 144.533665)">3.32</text>
     </g>
     <g id="patch_51">
-     <path d="M 1119.195 124.698353 
-L 1211.766187 124.698353 
-L 1211.766187 100.698353 
-L 1119.195 100.698353 
+     <path d="M 466.440562 153.498353 
+L 576.029438 153.498353 
+L 576.029438 129.498353 
+L 466.440562 129.498353 
 z
-" style="fill: #08773f; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #d3ec87; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_52">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="115.733665" transform="rotate(-0 1128.452119 115.733665)">29.80</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="144.533665" transform="rotate(-0 477.39945 144.533665)">32.21</text>
     </g>
     <g id="patch_52">
-     <path d="M 1211.766187 124.698353 
-L 1351.182937 124.698353 
-L 1351.182937 100.698353 
-L 1211.766187 100.698353 
+     <path d="M 576.029438 153.498353 
+L 639.014063 153.498353 
+L 639.014063 129.498353 
+L 576.029438 129.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_53">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="115.733665" transform="rotate(-0 1225.707862 115.733665)">2.19</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="144.533665" transform="rotate(-0 582.3279 144.533665)">604.36</text>
     </g>
     <g id="patch_53">
-     <path d="M 1351.182937 124.698353 
-L 1435.57425 124.698353 
-L 1435.57425 100.698353 
-L 1351.182937 100.698353 
+     <path d="M 639.014063 153.498353 
+L 744.40575 153.498353 
+L 744.40575 129.498353 
+L 639.014063 129.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #8ecf67; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_54">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="115.733665" transform="rotate(-0 1359.622069 115.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="144.533665" transform="rotate(-0 649.553231 144.533665)">15.99</text>
     </g>
     <g id="patch_54">
-     <path d="M 0 148.698353 
-L 128.297812 148.698353 
-L 128.297812 124.698353 
-L 0 124.698353 
+     <path d="M 744.40575 153.498353 
+L 881.238187 153.498353 
+L 881.238187 129.498353 
+L 744.40575 129.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #feeb9d; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_55">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="139.733665" transform="rotate(-0 12.829781 139.733665)">LPD-YuNet</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="144.533665" transform="rotate(-0 758.088994 144.533665)">64.96</text>
     </g>
     <g id="patch_55">
-     <path d="M 128.297812 148.698353 
-L 335.566687 148.698353 
-L 335.566687 124.698353 
-L 128.297812 124.698353 
+     <path d="M 881.238187 153.498353 
+L 982.407937 153.498353 
+L 982.407937 129.498353 
+L 881.238187 129.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_56">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="139.733665" transform="rotate(-0 149.0247 139.733665)">License Plate Detection</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="144.533665" transform="rotate(-0 891.355163 144.533665)">811.32</text>
     </g>
     <g id="patch_56">
-     <path d="M 335.566687 148.698353 
-L 402.168937 148.698353 
-L 402.168937 124.698353 
-L 335.566687 124.698353 
+     <path d="M 982.407937 153.498353 
+L 1071.918375 153.498353 
+L 1071.918375 129.498353 
+L 982.407937 129.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #c5e67e; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_57">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="139.733665" transform="rotate(-0 342.226912 139.733665)">320x240</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="144.533665" transform="rotate(-0 991.358981 144.533665)">28.19</text>
     </g>
     <g id="patch_57">
-     <path d="M 402.168937 148.698353 
-L 505.524937 148.698353 
-L 505.524937 124.698353 
-L 402.168937 124.698353 
+     <path d="M 1071.918375 153.498353 
+L 1168.705313 153.498353 
+L 1168.705313 129.498353 
+L 1071.918375 129.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #c9e881; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_58">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="139.733665" transform="rotate(-0 412.504537 139.733665)">8.63</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="144.533665" transform="rotate(-0 1081.597069 144.533665)">29.36</text>
     </g>
     <g id="patch_58">
-     <path d="M 505.524937 148.698353 
-L 592.378875 148.698353 
-L 592.378875 124.698353 
-L 505.524937 124.698353 
+     <path d="M 1168.705313 153.498353 
+L 1264.448625 153.498353 
+L 1264.448625 129.498353 
+L 1168.705313 129.498353 
 z
-" style="fill: #097940; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #f7fcb4; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_59">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="139.733665" transform="rotate(-0 514.210331 139.733665)">167.70</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="144.533665" transform="rotate(-0 1178.279644 144.533665)">47.71</text>
     </g>
     <g id="patch_59">
-     <path d="M 592.378875 148.698353 
-L 709.27725 148.698353 
-L 709.27725 124.698353 
-L 592.378875 124.698353 
+     <path d="M 1264.448625 153.498353 
+L 1353.959063 153.498353 
+L 1353.959063 129.498353 
+L 1264.448625 129.498353 
 z
-" style="fill: #f98e52; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a9da6c; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_60">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="139.733665" transform="rotate(-0 604.068712 139.733665)">3222.92</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="144.533665" transform="rotate(-0 1273.399669 144.533665)">20.64</text>
     </g>
     <g id="patch_60">
-     <path d="M 709.27725 148.698353 
-L 809.53125 148.698353 
-L 809.53125 124.698353 
-L 709.27725 124.698353 
+     <path d="M 1353.959063 153.498353 
+L 1450.746 153.498353 
+L 1450.746 129.498353 
+L 1353.959063 129.498353 
 z
-" style="fill: #026c39; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #e8f59f; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_61">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="139.733665" transform="rotate(-0 719.30265 139.733665)">57.57</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="144.533665" transform="rotate(-0 1363.637756 144.533665)">40.38</text>
     </g>
     <g id="patch_61">
-     <path d="M 809.53125 148.698353 
-L 911.107312 148.698353 
-L 911.107312 124.698353 
-L 809.53125 124.698353 
+     <path d="M 1450.746 153.498353 
+L 1546.489312 153.498353 
+L 1546.489312 129.498353 
+L 1450.746 129.498353 
 z
-" style="fill: #108647; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_62">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="139.733665" transform="rotate(-0 819.688856 139.733665)">283.75</text>
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="144.533665" transform="rotate(-0 1460.320331 144.533665)">2.19</text>
     </g>
     <g id="patch_62">
-     <path d="M 911.107312 148.698353 
-L 1002.669937 148.698353 
-L 1002.669937 124.698353 
-L 911.107312 124.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/license_plate_detection_yunet">
+      <path d="M 0 177.498353 
+L 128.297812 177.498353 
+L 128.297812 153.498353 
+L 0 153.498353 
 z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_63">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="139.733665" transform="rotate(-0 920.263575 139.733665)">4300.13</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/license_plate_detection_yunet">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="168.227728" transform="rotate(-0 12.829781 168.227728)">LPD_YuNet</text>
+     </a>
     </g>
     <g id="patch_63">
-     <path d="M 1002.669937 148.698353 
-L 1119.195 148.698353 
-L 1119.195 124.698353 
-L 1002.669937 124.698353 
+     <path d="M 128.297812 177.498353 
+L 335.566688 177.498353 
+L 335.566688 153.498353 
+L 128.297812 153.498353 
 z
-" style="fill: #026c39; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_64">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="139.733665" transform="rotate(-0 1014.322444 139.733665)">56.12</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="168.533665" transform="rotate(-0 149.0247 168.533665)">License Plate Detection</text>
     </g>
     <g id="patch_64">
-     <path d="M 1119.195 148.698353 
-L 1211.766187 148.698353 
-L 1211.766187 124.698353 
-L 1119.195 124.698353 
+     <path d="M 335.566688 177.498353 
+L 410.291063 177.498353 
+L 410.291063 153.498353 
+L 335.566688 153.498353 
 z
-" style="fill: #016a38; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_65">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="139.733665" transform="rotate(-0 1128.452119 139.733665)">29.53</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="168.533665" transform="rotate(-0 343.039125 168.533665)">320x240</text>
     </g>
     <g id="patch_65">
-     <path d="M 1211.766187 148.698353 
-L 1351.182937 148.698353 
-L 1351.182937 124.698353 
-L 1211.766187 124.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_66">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="139.733665" transform="rotate(-0 1225.707862 139.733665)">7.63</text>
-    </g>
-    <g id="patch_66">
-     <path d="M 1351.182937 148.698353 
-L 1435.57425 148.698353 
-L 1435.57425 124.698353 
-L 1351.182937 124.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_67">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="139.733665" transform="rotate(-0 1359.622069 139.733665)">---</text>
-    </g>
-    <g id="patch_67">
-     <path d="M 0 172.698353 
-L 128.297812 172.698353 
-L 128.297812 148.698353 
-L 0 148.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_68">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="163.733665" transform="rotate(-0 12.829781 163.733665)">YOLOX</text>
-    </g>
-    <g id="patch_68">
-     <path d="M 128.297812 172.698353 
-L 335.566687 172.698353 
-L 335.566687 148.698353 
-L 128.297812 148.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_69">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="163.733665" transform="rotate(-0 149.0247 163.733665)">Object Detection</text>
-    </g>
-    <g id="patch_69">
-     <path d="M 335.566687 172.698353 
-L 402.168937 172.698353 
-L 402.168937 148.698353 
-L 335.566687 148.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_70">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="163.733665" transform="rotate(-0 342.226912 163.733665)">640x640</text>
-    </g>
-    <g id="patch_70">
-     <path d="M 402.168937 172.698353 
-L 505.524937 172.698353 
-L 505.524937 148.698353 
-L 402.168937 148.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_71">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="163.733665" transform="rotate(-0 412.504537 163.733665)">141.20</text>
-    </g>
-    <g id="patch_71">
-     <path d="M 505.524937 172.698353 
-L 592.378875 172.698353 
-L 592.378875 148.698353 
-L 505.524937 148.698353 
+     <path d="M 410.291063 177.498353 
+L 466.440562 177.498353 
+L 466.440562 153.498353 
+L 410.291063 153.498353 
 z
 " style="fill: #097940; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_72">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="163.733665" transform="rotate(-0 514.210331 163.733665)">1805.87</text>
+    <g id="text_66">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="168.533665" transform="rotate(-0 415.906013 168.533665)">8.53</text>
     </g>
-    <g id="patch_72">
-     <path d="M 592.378875 172.698353 
-L 709.27725 172.698353 
-L 709.27725 148.698353 
-L 592.378875 148.698353 
+    <g id="patch_66">
+     <path d="M 466.440562 177.498353 
+L 576.029438 177.498353 
+L 576.029438 153.498353 
+L 466.440562 153.498353 
 z
-" style="fill: #f7814c; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #fffab6; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_73">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="163.733665" transform="rotate(-0 604.068712 163.733665)">38359.93</text>
+    <g id="text_67">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="168.533665" transform="rotate(-0 477.39945 168.533665)">192.61</text>
     </g>
-    <g id="patch_73">
-     <path d="M 709.27725 172.698353 
-L 809.53125 172.698353 
-L 809.53125 148.698353 
-L 709.27725 148.698353 
-z
-" style="fill: #026c39; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_74">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="163.733665" transform="rotate(-0 719.30265 163.733665)">577.93</text>
-    </g>
-    <g id="patch_74">
-     <path d="M 809.53125 172.698353 
-L 911.107312 172.698353 
-L 911.107312 148.698353 
-L 809.53125 148.698353 
-z
-" style="fill: #0d8044; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_75">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="163.733665" transform="rotate(-0 819.688856 163.733665)">2749.22</text>
-    </g>
-    <g id="patch_75">
-     <path d="M 911.107312 172.698353 
-L 1002.669937 172.698353 
-L 1002.669937 148.698353 
-L 911.107312 148.698353 
+    <g id="patch_67">
+     <path d="M 576.029438 177.498353 
+L 639.014063 177.498353 
+L 639.014063 153.498353 
+L 576.029438 153.498353 
 z
 " style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_68">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="168.533665" transform="rotate(-0 582.3279 168.533665)">3222.92</text>
+    </g>
+    <g id="patch_68">
+     <path d="M 639.014063 177.498353 
+L 744.40575 177.498353 
+L 744.40575 153.498353 
+L 639.014063 153.498353 
+z
+" style="fill: #91d068; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_69">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="168.533665" transform="rotate(-0 649.553231 168.533665)">57.57</text>
+    </g>
+    <g id="patch_69">
+     <path d="M 744.40575 177.498353 
+L 881.238187 177.498353 
+L 881.238187 153.498353 
+L 744.40575 153.498353 
+z
+" style="fill: #fed07e; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_70">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="168.533665" transform="rotate(-0 758.088994 168.533665)">283.75</text>
+    </g>
+    <g id="patch_70">
+     <path d="M 881.238187 177.498353 
+L 982.407937 177.498353 
+L 982.407937 153.498353 
+L 881.238187 153.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_71">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="168.533665" transform="rotate(-0 891.355163 168.533665)">4300.13</text>
+    </g>
+    <g id="patch_71">
+     <path d="M 982.407937 177.498353 
+L 1071.918375 177.498353 
+L 1071.918375 153.498353 
+L 982.407937 153.498353 
+z
+" style="fill: #e3f399; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_72">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="168.533665" transform="rotate(-0 991.358981 168.533665)">133.15</text>
+    </g>
+    <g id="patch_72">
+     <path d="M 1071.918375 177.498353 
+L 1168.705313 177.498353 
+L 1168.705313 153.498353 
+L 1071.918375 153.498353 
+z
+" style="fill: #dcf08f; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_73">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="168.533665" transform="rotate(-0 1081.597069 168.533665)">122.17</text>
+    </g>
+    <g id="patch_73">
+     <path d="M 1168.705313 177.498353 
+L 1264.448625 177.498353 
+L 1264.448625 153.498353 
+L 1168.705313 153.498353 
+z
+" style="fill: #feec9f; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_74">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="168.533665" transform="rotate(-0 1178.279644 168.533665)">226.08</text>
+    </g>
+    <g id="patch_74">
+     <path d="M 1264.448625 177.498353 
+L 1353.959063 177.498353 
+L 1353.959063 153.498353 
+L 1264.448625 153.498353 
+z
+" style="fill: #89cc67; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_75">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="168.533665" transform="rotate(-0 1273.399669 168.533665)">53.50</text>
+    </g>
+    <g id="patch_75">
+     <path d="M 1353.959063 177.498353 
+L 1450.746 177.498353 
+L 1450.746 153.498353 
+L 1353.959063 153.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
     <g id="text_76">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="163.733665" transform="rotate(-0 920.263575 163.733665)">49994.75</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="168.533665" transform="rotate(-0 1363.637756 168.533665)">---</text>
     </g>
     <g id="patch_76">
-     <path d="M 1002.669937 172.698353 
-L 1119.195 172.698353 
-L 1119.195 148.698353 
-L 1002.669937 148.698353 
-z
-" style="fill: #016a38; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_77">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="163.733665" transform="rotate(-0 1014.322444 163.733665)">388.95</text>
-    </g>
-    <g id="patch_77">
-     <path d="M 1119.195 172.698353 
-L 1211.766187 172.698353 
-L 1211.766187 148.698353 
-L 1119.195 148.698353 
-z
-" style="fill: #026c39; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_78">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="163.733665" transform="rotate(-0 1128.452119 163.733665)">420.98</text>
-    </g>
-    <g id="patch_78">
-     <path d="M 1211.766187 172.698353 
-L 1351.182937 172.698353 
-L 1351.182937 148.698353 
-L 1211.766187 148.698353 
+     <path d="M 1450.746 177.498353 
+L 1546.489312 177.498353 
+L 1546.489312 153.498353 
+L 1450.746 153.498353 
 z
 " style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_77">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="168.533665" transform="rotate(-0 1460.320331 168.533665)">7.63</text>
+    </g>
+    <g id="patch_77">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/object_detection_yolox">
+      <path d="M 0 201.498353 
+L 128.297812 201.498353 
+L 128.297812 177.498353 
+L 0 177.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
+    <g id="text_78">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/object_detection_yolox">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="192.533665" transform="rotate(-0 12.829781 192.533665)">YOLOX</text>
+     </a>
+    </g>
+    <g id="patch_78">
+     <path d="M 128.297812 201.498353 
+L 335.566688 201.498353 
+L 335.566688 177.498353 
+L 128.297812 177.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
     <g id="text_79">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="163.733665" transform="rotate(-0 1225.707862 163.733665)">28.59</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="192.533665" transform="rotate(-0 149.0247 192.533665)">Object Detection</text>
     </g>
     <g id="patch_79">
-     <path d="M 1351.182937 172.698353 
-L 1435.57425 172.698353 
-L 1435.57425 148.698353 
-L 1351.182937 148.698353 
+     <path d="M 335.566688 201.498353 
+L 410.291063 201.498353 
+L 410.291063 177.498353 
+L 335.566688 177.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_80">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="163.733665" transform="rotate(-0 1359.622069 163.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="192.533665" transform="rotate(-0 343.039125 192.533665)">640x640</text>
     </g>
     <g id="patch_80">
-     <path d="M 0 196.698353 
-L 128.297812 196.698353 
-L 128.297812 172.698353 
-L 0 172.698353 
+     <path d="M 410.291063 201.498353 
+L 466.440562 201.498353 
+L 466.440562 177.498353 
+L 410.291063 177.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #63bc62; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_81">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="187.733665" transform="rotate(-0 12.829781 187.733665)">NanoDet</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="192.533665" transform="rotate(-0 415.906013 192.533665)">137.53</text>
     </g>
     <g id="patch_81">
-     <path d="M 128.297812 196.698353 
-L 335.566687 196.698353 
-L 335.566687 172.698353 
-L 128.297812 172.698353 
+     <path d="M 466.440562 201.498353 
+L 576.029438 201.498353 
+L 576.029438 177.498353 
+L 466.440562 177.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #eb5a3a; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_82">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="187.733665" transform="rotate(-0 149.0247 187.733665)">Object Detection</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="192.533665" transform="rotate(-0 477.39945 192.533665)">1932.97</text>
     </g>
     <g id="patch_82">
-     <path d="M 335.566687 196.698353 
-L 402.168937 196.698353 
-L 402.168937 172.698353 
-L 335.566687 172.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_83">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="187.733665" transform="rotate(-0 342.226912 187.733665)">416x416</text>
-    </g>
-    <g id="patch_83">
-     <path d="M 402.168937 196.698353 
-L 505.524937 196.698353 
-L 505.524937 172.698353 
-L 402.168937 172.698353 
-z
-" style="fill: #036e3a; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_84">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="187.733665" transform="rotate(-0 412.504537 187.733665)">66.03</text>
-    </g>
-    <g id="patch_84">
-     <path d="M 505.524937 196.698353 
-L 592.378875 196.698353 
-L 592.378875 172.698353 
-L 505.524937 172.698353 
-z
-" style="fill: #0f8446; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_85">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="187.733665" transform="rotate(-0 514.210331 187.733665)">225.10</text>
-    </g>
-    <g id="patch_85">
-     <path d="M 592.378875 196.698353 
-L 709.27725 196.698353 
-L 709.27725 172.698353 
-L 592.378875 172.698353 
-z
-" style="fill: #fdb567; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_86">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="187.733665" transform="rotate(-0 604.068712 187.733665)">2303.55</text>
-    </g>
-    <g id="patch_86">
-     <path d="M 709.27725 196.698353 
-L 809.53125 196.698353 
-L 809.53125 172.698353 
-L 709.27725 172.698353 
-z
-" style="fill: #07753e; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_87">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="187.733665" transform="rotate(-0 719.30265 187.733665)">118.38</text>
-    </g>
-    <g id="patch_87">
-     <path d="M 809.53125 196.698353 
-L 911.107312 196.698353 
-L 911.107312 172.698353 
-L 809.53125 172.698353 
-z
-" style="fill: #249d53; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_88">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="187.733665" transform="rotate(-0 819.688856 187.733665)">408.16</text>
-    </g>
-    <g id="patch_88">
-     <path d="M 911.107312 196.698353 
-L 1002.669937 196.698353 
-L 1002.669937 172.698353 
-L 911.107312 172.698353 
+     <path d="M 576.029438 201.498353 
+L 639.014063 201.498353 
+L 639.014063 177.498353 
+L 576.029438 177.498353 
 z
 " style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_83">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="192.533665" transform="rotate(-0 582.3279 192.533665)">38359.93</text>
+    </g>
+    <g id="patch_83">
+     <path d="M 639.014063 201.498353 
+L 744.40575 201.498353 
+L 744.40575 177.498353 
+L 639.014063 177.498353 
+z
+" style="fill: #e9f6a1; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_84">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="192.533665" transform="rotate(-0 649.553231 192.533665)">577.93</text>
+    </g>
+    <g id="patch_84">
+     <path d="M 744.40575 201.498353 
+L 881.238187 201.498353 
+L 881.238187 177.498353 
+L 744.40575 177.498353 
+z
+" style="fill: #a90426; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_85">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="192.533665" transform="rotate(-0 758.088994 192.533665)">2749.22</text>
+    </g>
+    <g id="patch_85">
+     <path d="M 881.238187 201.498353 
+L 982.407937 201.498353 
+L 982.407937 177.498353 
+L 881.238187 177.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_86">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="192.533665" transform="rotate(-0 891.355163 192.533665)">49994.75</text>
+    </g>
+    <g id="patch_86">
+     <path d="M 982.407937 201.498353 
+L 1071.918375 201.498353 
+L 1071.918375 177.498353 
+L 982.407937 177.498353 
+z
+" style="fill: #fdc372; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_87">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="192.533665" transform="rotate(-0 991.358981 192.533665)">1228.13</text>
+    </g>
+    <g id="patch_87">
+     <path d="M 1071.918375 201.498353 
+L 1168.705313 201.498353 
+L 1168.705313 177.498353 
+L 1071.918375 177.498353 
+z
+" style="fill: #fec877; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_88">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="192.533665" transform="rotate(-0 1081.597069 192.533665)">1189.83</text>
+    </g>
+    <g id="patch_88">
+     <path d="M 1168.705313 201.498353 
+L 1264.448625 201.498353 
+L 1264.448625 177.498353 
+L 1168.705313 177.498353 
+z
+" style="fill: #e75337; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
     <g id="text_89">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="187.733665" transform="rotate(-0 920.263575 187.733665)">3360.20</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="192.533665" transform="rotate(-0 1178.279644 192.533665)">1995.97</text>
     </g>
     <g id="patch_89">
-     <path d="M 1002.669937 196.698353 
-L 1119.195 196.698353 
-L 1119.195 172.698353 
-L 1002.669937 172.698353 
+     <path d="M 1264.448625 201.498353 
+L 1353.959063 201.498353 
+L 1353.959063 177.498353 
+L 1264.448625 177.498353 
 z
-" style="fill: #036e3a; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #fdc171; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_90">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="187.733665" transform="rotate(-0 1014.322444 187.733665)">64.94</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="192.533665" transform="rotate(-0 1273.399669 192.533665)">1238.91</text>
     </g>
     <g id="patch_90">
-     <path d="M 1119.195 196.698353 
-L 1211.766187 196.698353 
-L 1211.766187 172.698353 
-L 1119.195 172.698353 
+     <path d="M 1353.959063 201.498353 
+L 1450.746 201.498353 
+L 1450.746 177.498353 
+L 1353.959063 177.498353 
 z
-" style="fill: #07753e; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #fed481; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_91">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="187.733665" transform="rotate(-0 1128.452119 187.733665)">116.64</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="192.533665" transform="rotate(-0 1363.637756 192.533665)">1103.24</text>
     </g>
     <g id="patch_91">
-     <path d="M 1211.766187 196.698353 
-L 1351.182937 196.698353 
-L 1351.182937 172.698353 
-L 1211.766187 172.698353 
+     <path d="M 1450.746 201.498353 
+L 1546.489312 201.498353 
+L 1546.489312 177.498353 
+L 1450.746 177.498353 
 z
 " style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_92">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="187.733665" transform="rotate(-0 1225.707862 187.733665)">20.62</text>
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="192.533665" transform="rotate(-0 1460.320331 192.533665)">28.59</text>
     </g>
     <g id="patch_92">
-     <path d="M 1351.182937 196.698353 
-L 1435.57425 196.698353 
-L 1435.57425 172.698353 
-L 1351.182937 172.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/object_detection_nanodet">
+      <path d="M 0 225.498353 
+L 128.297812 225.498353 
+L 128.297812 201.498353 
+L 0 201.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_93">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="187.733665" transform="rotate(-0 1359.622069 187.733665)">---</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/object_detection_nanodet">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="216.533665" transform="rotate(-0 12.829781 216.533665)">NanoDet</text>
+     </a>
     </g>
     <g id="patch_93">
-     <path d="M 0 220.698353 
-L 128.297812 220.698353 
-L 128.297812 196.698353 
-L 0 196.698353 
+     <path d="M 128.297812 225.498353 
+L 335.566688 225.498353 
+L 335.566688 201.498353 
+L 128.297812 201.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_94">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="211.733665" transform="rotate(-0 12.829781 211.733665)">DB-IC15 (EN)</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="216.533665" transform="rotate(-0 149.0247 216.533665)">Object Detection</text>
     </g>
     <g id="patch_94">
-     <path d="M 128.297812 220.698353 
-L 335.566687 220.698353 
-L 335.566687 196.698353 
-L 128.297812 196.698353 
+     <path d="M 335.566688 225.498353 
+L 410.291063 225.498353 
+L 410.291063 201.498353 
+L 335.566688 201.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_95">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="211.733665" transform="rotate(-0 149.0247 211.733665)">Text Detection</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="216.533665" transform="rotate(-0 343.039125 216.533665)">416x416</text>
     </g>
     <g id="patch_95">
-     <path d="M 335.566687 220.698353 
-L 402.168937 220.698353 
-L 402.168937 196.698353 
-L 335.566687 196.698353 
+     <path d="M 410.291063 225.498353 
+L 466.440562 225.498353 
+L 466.440562 201.498353 
+L 410.291063 201.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #3faa59; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_96">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="211.733665" transform="rotate(-0 342.226912 211.733665)">640x480</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="216.533665" transform="rotate(-0 415.906013 216.533665)">65.15</text>
     </g>
     <g id="patch_96">
-     <path d="M 402.168937 220.698353 
-L 505.524937 220.698353 
-L 505.524937 196.698353 
-L 402.168937 196.698353 
+     <path d="M 466.440562 225.498353 
+L 576.029438 225.498353 
+L 576.029438 201.498353 
+L 466.440562 201.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #b9e176; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_97">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="211.733665" transform="rotate(-0 412.504537 211.733665)">71.03</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="216.533665" transform="rotate(-0 477.39945 216.533665)">248.03</text>
     </g>
     <g id="patch_97">
-     <path d="M 505.524937 220.698353 
-L 592.378875 220.698353 
-L 592.378875 196.698353 
-L 505.524937 196.698353 
-z
-" style="fill: #07753e; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_98">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="211.733665" transform="rotate(-0 514.210331 211.733665)">1862.75</text>
-    </g>
-    <g id="patch_98">
-     <path d="M 592.378875 220.698353 
-L 709.27725 220.698353 
-L 709.27725 196.698353 
-L 592.378875 196.698353 
-z
-" style="fill: #f98e52; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_99">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="211.733665" transform="rotate(-0 604.068712 211.733665)">49065.03</text>
-    </g>
-    <g id="patch_99">
-     <path d="M 709.27725 220.698353 
-L 809.53125 220.698353 
-L 809.53125 196.698353 
-L 709.27725 196.698353 
-z
-" style="fill: #016a38; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_100">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="211.733665" transform="rotate(-0 719.30265 211.733665)">394.77</text>
-    </g>
-    <g id="patch_100">
-     <path d="M 809.53125 220.698353 
-L 911.107312 220.698353 
-L 911.107312 196.698353 
-L 809.53125 196.698353 
-z
-" style="fill: #07753e; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_101">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="211.733665" transform="rotate(-0 819.688856 211.733665)">1908.87</text>
-    </g>
-    <g id="patch_101">
-     <path d="M 911.107312 220.698353 
-L 1002.669937 220.698353 
-L 1002.669937 196.698353 
-L 911.107312 196.698353 
+     <path d="M 576.029438 225.498353 
+L 639.014063 225.498353 
+L 639.014063 201.498353 
+L 576.029438 201.498353 
 z
 " style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_98">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="216.533665" transform="rotate(-0 582.3279 216.533665)">2303.55</text>
+    </g>
+    <g id="patch_98">
+     <path d="M 639.014063 225.498353 
+L 744.40575 225.498353 
+L 744.40575 201.498353 
+L 639.014063 201.498353 
+z
+" style="fill: #73c264; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_99">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="216.533665" transform="rotate(-0 649.553231 216.533665)">118.38</text>
+    </g>
+    <g id="patch_99">
+     <path d="M 744.40575 225.498353 
+L 881.238187 225.498353 
+L 881.238187 201.498353 
+L 744.40575 201.498353 
+z
+" style="fill: #e9f6a1; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_100">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="216.533665" transform="rotate(-0 758.088994 216.533665)">408.16</text>
+    </g>
+    <g id="patch_100">
+     <path d="M 881.238187 225.498353 
+L 982.407937 225.498353 
+L 982.407937 201.498353 
+L 881.238187 201.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_101">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="216.533665" transform="rotate(-0 891.355163 216.533665)">3360.20</text>
+    </g>
+    <g id="patch_101">
+     <path d="M 982.407937 225.498353 
+L 1071.918375 225.498353 
+L 1071.918375 201.498353 
+L 982.407937 201.498353 
+z
+" style="fill: #addc6f; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
     <g id="text_102">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="211.733665" transform="rotate(-0 920.263575 211.733665)">65681.91</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="216.533665" transform="rotate(-0 991.358981 216.533665)">215.57</text>
     </g>
     <g id="patch_102">
-     <path d="M 1002.669937 220.698353 
-L 1119.195 220.698353 
-L 1119.195 196.698353 
-L 1002.669937 196.698353 
+     <path d="M 1071.918375 225.498353 
+L 1168.705313 225.498353 
+L 1168.705313 201.498353 
+L 1071.918375 201.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a9da6c; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_103">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="211.733665" transform="rotate(-0 1014.322444 211.733665)">208.41</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="216.533665" transform="rotate(-0 1081.597069 216.533665)">208.25</text>
     </g>
     <g id="patch_103">
-     <path d="M 1119.195 220.698353 
-L 1211.766187 220.698353 
-L 1211.766187 196.698353 
-L 1119.195 196.698353 
+     <path d="M 1168.705313 225.498353 
+L 1264.448625 225.498353 
+L 1264.448625 201.498353 
+L 1168.705313 201.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #daf08d; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_104">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="211.733665" transform="rotate(-0 1128.452119 211.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="216.533665" transform="rotate(-0 1178.279644 216.533665)">343.08</text>
     </g>
     <g id="patch_104">
-     <path d="M 1211.766187 220.698353 
-L 1351.182937 220.698353 
-L 1351.182937 196.698353 
-L 1211.766187 196.698353 
+     <path d="M 1264.448625 225.498353 
+L 1353.959063 225.498353 
+L 1353.959063 201.498353 
+L 1264.448625 201.498353 
+z
+" style="fill: #addc6f; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_105">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="216.533665" transform="rotate(-0 1273.399669 216.533665)">214.99</text>
+    </g>
+    <g id="patch_105">
+     <path d="M 1353.959063 225.498353 
+L 1450.746 225.498353 
+L 1450.746 201.498353 
+L 1353.959063 201.498353 
+z
+" style="fill: #a7d96b; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_106">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="216.533665" transform="rotate(-0 1363.637756 216.533665)">200.50</text>
+    </g>
+    <g id="patch_106">
+     <path d="M 1450.746 225.498353 
+L 1546.489312 225.498353 
+L 1546.489312 201.498353 
+L 1450.746 201.498353 
 z
 " style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_105">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="211.733665" transform="rotate(-0 1225.707862 211.733665)">17.15</text>
-    </g>
-    <g id="patch_105">
-     <path d="M 1351.182937 220.698353 
-L 1435.57425 220.698353 
-L 1435.57425 196.698353 
-L 1351.182937 196.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_106">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="211.733665" transform="rotate(-0 1359.622069 211.733665)">---</text>
-    </g>
-    <g id="patch_106">
-     <path d="M 0 244.698353 
-L 128.297812 244.698353 
-L 128.297812 220.698353 
-L 0 220.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
     <g id="text_107">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="235.733665" transform="rotate(-0 12.829781 235.733665)">DB-TD500 (EN&amp;CN)</text>
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="216.533665" transform="rotate(-0 1460.320331 216.533665)">20.62</text>
     </g>
     <g id="patch_107">
-     <path d="M 128.297812 244.698353 
-L 335.566687 244.698353 
-L 335.566687 220.698353 
-L 128.297812 220.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/text_detection_db">
+      <path d="M 0 249.498353 
+L 128.297812 249.498353 
+L 128.297812 225.498353 
+L 0 225.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_108">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="235.733665" transform="rotate(-0 149.0247 235.733665)">Text Detection</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/text_detection_db">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="240.533665" transform="rotate(-0 12.829781 240.533665)">DB-IC15 (EN)</text>
+     </a>
     </g>
     <g id="patch_108">
-     <path d="M 335.566687 244.698353 
-L 402.168937 244.698353 
-L 402.168937 220.698353 
-L 335.566687 220.698353 
+     <path d="M 128.297812 249.498353 
+L 335.566688 249.498353 
+L 335.566688 225.498353 
+L 128.297812 225.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_109">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="235.733665" transform="rotate(-0 342.226912 235.733665)">640x480</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="240.533665" transform="rotate(-0 149.0247 240.533665)">Text Detection</text>
     </g>
     <g id="patch_109">
-     <path d="M 402.168937 244.698353 
-L 505.524937 244.698353 
-L 505.524937 220.698353 
-L 402.168937 220.698353 
+     <path d="M 335.566688 249.498353 
+L 410.291063 249.498353 
+L 410.291063 225.498353 
+L 335.566688 225.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_110">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="235.733665" transform="rotate(-0 412.504537 235.733665)">72.31</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="240.533665" transform="rotate(-0 343.039125 240.533665)">640x480</text>
     </g>
     <g id="patch_110">
-     <path d="M 505.524937 244.698353 
-L 592.378875 244.698353 
-L 592.378875 220.698353 
-L 505.524937 220.698353 
+     <path d="M 410.291063 249.498353 
+L 466.440562 249.498353 
+L 466.440562 225.498353 
+L 410.291063 225.498353 
 z
-" style="fill: #07753e; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #51b35e; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_111">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="235.733665" transform="rotate(-0 514.210331 235.733665)">1878.45</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="240.533665" transform="rotate(-0 415.906013 240.533665)">75.82</text>
     </g>
     <g id="patch_111">
-     <path d="M 592.378875 244.698353 
-L 709.27725 244.698353 
-L 709.27725 220.698353 
-L 592.378875 220.698353 
-z
-" style="fill: #f98e52; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_112">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="235.733665" transform="rotate(-0 604.068712 235.733665)">49052.24</text>
-    </g>
-    <g id="patch_112">
-     <path d="M 709.27725 244.698353 
-L 809.53125 244.698353 
-L 809.53125 220.698353 
-L 709.27725 220.698353 
-z
-" style="fill: #016a38; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_113">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="235.733665" transform="rotate(-0 719.30265 235.733665)">392.52</text>
-    </g>
-    <g id="patch_113">
-     <path d="M 809.53125 244.698353 
-L 911.107312 244.698353 
-L 911.107312 220.698353 
-L 809.53125 220.698353 
-z
-" style="fill: #07753e; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_114">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="235.733665" transform="rotate(-0 819.688856 235.733665)">1922.34</text>
-    </g>
-    <g id="patch_114">
-     <path d="M 911.107312 244.698353 
-L 1002.669937 244.698353 
-L 1002.669937 220.698353 
-L 911.107312 220.698353 
+     <path d="M 466.440562 249.498353 
+L 576.029438 249.498353 
+L 576.029438 225.498353 
+L 466.440562 225.498353 
 z
 " style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_112">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="240.533665" transform="rotate(-0 477.39945 240.533665)">2025.09</text>
+    </g>
+    <g id="patch_112">
+     <path d="M 576.029438 249.498353 
+L 639.014063 249.498353 
+L 639.014063 225.498353 
+L 576.029438 225.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_113">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="240.533665" transform="rotate(-0 582.3279 240.533665)">49065.03</text>
+    </g>
+    <g id="patch_113">
+     <path d="M 639.014063 249.498353 
+L 744.40575 249.498353 
+L 744.40575 225.498353 
+L 639.014063 225.498353 
+z
+" style="fill: #e6f59d; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_114">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="240.533665" transform="rotate(-0 649.553231 240.533665)">394.77</text>
+    </g>
+    <g id="patch_114">
+     <path d="M 744.40575 249.498353 
+L 881.238187 249.498353 
+L 881.238187 225.498353 
+L 744.40575 225.498353 
+z
+" style="fill: #af0926; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
     <g id="text_115">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="235.733665" transform="rotate(-0 920.263575 235.733665)">65630.56</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="240.533665" transform="rotate(-0 758.088994 240.533665)">1908.87</text>
     </g>
     <g id="patch_115">
-     <path d="M 1002.669937 244.698353 
-L 1119.195 244.698353 
-L 1119.195 220.698353 
-L 1002.669937 220.698353 
+     <path d="M 881.238187 249.498353 
+L 982.407937 249.498353 
+L 982.407937 225.498353 
+L 881.238187 225.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_116">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="235.733665" transform="rotate(-0 1014.322444 235.733665)">210.51</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="240.533665" transform="rotate(-0 891.355163 240.533665)">65681.91</text>
     </g>
     <g id="patch_116">
-     <path d="M 1119.195 244.698353 
-L 1211.766187 244.698353 
-L 1211.766187 220.698353 
-L 1119.195 220.698353 
+     <path d="M 982.407937 249.498353 
+L 1071.918375 249.498353 
+L 1071.918375 225.498353 
+L 982.407937 225.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #fa9656; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_117">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="235.733665" transform="rotate(-0 1128.452119 235.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="240.533665" transform="rotate(-0 991.358981 240.533665)">1089.89</text>
     </g>
     <g id="patch_117">
-     <path d="M 1211.766187 244.698353 
-L 1351.182937 244.698353 
-L 1351.182937 220.698353 
-L 1211.766187 220.698353 
+     <path d="M 1071.918375 249.498353 
+L 1168.705313 249.498353 
+L 1168.705313 225.498353 
+L 1071.918375 225.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #fdb163; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_118">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="235.733665" transform="rotate(-0 1225.707862 235.733665)">17.95</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="240.533665" transform="rotate(-0 1081.597069 240.533665)">973.75</text>
     </g>
     <g id="patch_118">
-     <path d="M 1351.182937 244.698353 
-L 1435.57425 244.698353 
-L 1435.57425 220.698353 
-L 1351.182937 220.698353 
+     <path d="M 1168.705313 249.498353 
+L 1264.448625 249.498353 
+L 1264.448625 225.498353 
+L 1168.705313 225.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #e54e35; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_119">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="235.733665" transform="rotate(-0 1359.622069 235.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="240.533665" transform="rotate(-0 1178.279644 240.533665)">1452.55</text>
     </g>
     <g id="patch_119">
-     <path d="M 0 268.698353 
-L 128.297812 268.698353 
-L 128.297812 244.698353 
-L 0 244.698353 
+     <path d="M 1264.448625 249.498353 
+L 1353.959063 249.498353 
+L 1353.959063 225.498353 
+L 1264.448625 225.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #cfeb85; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_120">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="259.733665" transform="rotate(-0 12.829781 259.733665)">CRNN-EN</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="240.533665" transform="rotate(-0 1273.399669 240.533665)">303.12</text>
     </g>
     <g id="patch_120">
-     <path d="M 128.297812 268.698353 
-L 335.566687 268.698353 
-L 335.566687 244.698353 
-L 128.297812 244.698353 
+     <path d="M 1353.959063 249.498353 
+L 1450.746 249.498353 
+L 1450.746 225.498353 
+L 1353.959063 225.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_121">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="259.733665" transform="rotate(-0 149.0247 259.733665)">Text Recognition</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="240.533665" transform="rotate(-0 1363.637756 240.533665)">---</text>
     </g>
     <g id="patch_121">
-     <path d="M 335.566687 268.698353 
-L 402.168937 268.698353 
-L 402.168937 244.698353 
-L 335.566687 244.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_122">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="259.733665" transform="rotate(-0 342.226912 259.733665)">100x32</text>
-    </g>
-    <g id="patch_122">
-     <path d="M 402.168937 268.698353 
-L 505.524937 268.698353 
-L 505.524937 244.698353 
-L 402.168937 244.698353 
+     <path d="M 1450.746 249.498353 
+L 1546.489312 249.498353 
+L 1546.489312 225.498353 
+L 1450.746 225.498353 
 z
 " style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_122">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="240.533665" transform="rotate(-0 1460.320331 240.533665)">17.15</text>
+    </g>
+    <g id="patch_122">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/text_detection_db">
+      <path d="M 0 273.498353 
+L 128.297812 273.498353 
+L 128.297812 249.498353 
+L 0 249.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
     <g id="text_123">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="259.733665" transform="rotate(-0 412.504537 259.733665)">20.16</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/text_detection_db">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="264.533665" transform="rotate(-0 12.829781 264.533665)">DB-TD500 (EN&amp;CN)</text>
+     </a>
     </g>
     <g id="patch_123">
-     <path d="M 505.524937 268.698353 
-L 592.378875 268.698353 
-L 592.378875 244.698353 
-L 505.524937 244.698353 
+     <path d="M 128.297812 273.498353 
+L 335.566688 273.498353 
+L 335.566688 249.498353 
+L 128.297812 249.498353 
 z
-" style="fill: #148e4b; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_124">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="259.733665" transform="rotate(-0 514.210331 259.733665)">278.11</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="264.533665" transform="rotate(-0 149.0247 264.533665)">Text Detection</text>
     </g>
     <g id="patch_124">
-     <path d="M 592.378875 268.698353 
-L 709.27725 268.698353 
-L 709.27725 244.698353 
-L 592.378875 244.698353 
+     <path d="M 335.566688 273.498353 
+L 410.291063 273.498353 
+L 410.291063 249.498353 
+L 335.566688 249.498353 
 z
-" style="fill: #fdb96a; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_125">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="259.733665" transform="rotate(-0 604.068712 259.733665)">2230.12</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="264.533665" transform="rotate(-0 343.039125 264.533665)">640x480</text>
     </g>
     <g id="patch_125">
-     <path d="M 709.27725 268.698353 
-L 809.53125 268.698353 
-L 809.53125 244.698353 
-L 709.27725 244.698353 
+     <path d="M 410.291063 273.498353 
+L 466.440562 273.498353 
+L 466.440562 249.498353 
+L 410.291063 249.498353 
 z
-" style="fill: #04703b; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #4eb15d; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_126">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="259.733665" transform="rotate(-0 719.30265 259.733665)">77.51</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="264.533665" transform="rotate(-0 415.906013 264.533665)">74.80</text>
     </g>
     <g id="patch_126">
-     <path d="M 809.53125 268.698353 
-L 911.107312 268.698353 
-L 911.107312 244.698353 
-L 809.53125 244.698353 
+     <path d="M 466.440562 273.498353 
+L 576.029438 273.498353 
+L 576.029438 249.498353 
+L 466.440562 249.498353 
 z
-" style="fill: #33a456; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_127">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="259.733665" transform="rotate(-0 819.688856 259.733665)">464.58</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="264.533665" transform="rotate(-0 477.39945 264.533665)">2041.85</text>
     </g>
     <g id="patch_127">
-     <path d="M 911.107312 268.698353 
-L 1002.669937 268.698353 
-L 1002.669937 244.698353 
-L 911.107312 244.698353 
+     <path d="M 576.029438 273.498353 
+L 639.014063 273.498353 
+L 639.014063 249.498353 
+L 576.029438 249.498353 
 z
 " style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_128">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="259.733665" transform="rotate(-0 920.263575 259.733665)">3277.07</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="264.533665" transform="rotate(-0 582.3279 264.533665)">49052.24</text>
     </g>
     <g id="patch_128">
-     <path d="M 1002.669937 268.698353 
-L 1119.195 268.698353 
-L 1119.195 244.698353 
-L 1002.669937 244.698353 
+     <path d="M 639.014063 273.498353 
+L 744.40575 273.498353 
+L 744.40575 249.498353 
+L 639.014063 249.498353 
 z
-" style="fill: #0d8044; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #e6f59d; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_129">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="259.733665" transform="rotate(-0 1014.322444 259.733665)">196.15</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="264.533665" transform="rotate(-0 649.553231 264.533665)">392.52</text>
     </g>
     <g id="patch_129">
-     <path d="M 1119.195 268.698353 
-L 1211.766187 268.698353 
-L 1211.766187 244.698353 
-L 1119.195 244.698353 
+     <path d="M 744.40575 273.498353 
+L 881.238187 273.498353 
+L 881.238187 249.498353 
+L 744.40575 249.498353 
 z
-" style="fill: #08773f; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #af0926; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_130">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="259.733665" transform="rotate(-0 1128.452119 259.733665)">125.30</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="264.533665" transform="rotate(-0 758.088994 264.533665)">1922.34</text>
     </g>
     <g id="patch_130">
-     <path d="M 1211.766187 268.698353 
-L 1351.182937 268.698353 
-L 1351.182937 244.698353 
-L 1211.766187 244.698353 
+     <path d="M 881.238187 273.498353 
+L 982.407937 273.498353 
+L 982.407937 249.498353 
+L 881.238187 249.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_131">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="259.733665" transform="rotate(-0 1225.707862 259.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="264.533665" transform="rotate(-0 891.355163 264.533665)">65630.56</text>
     </g>
     <g id="patch_131">
-     <path d="M 1351.182937 268.698353 
-L 1435.57425 268.698353 
-L 1435.57425 244.698353 
-L 1351.182937 244.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_132">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="259.733665" transform="rotate(-0 1359.622069 259.733665)">---</text>
-    </g>
-    <g id="patch_132">
-     <path d="M 0 292.698353 
-L 128.297812 292.698353 
-L 128.297812 268.698353 
-L 0 268.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_133">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="283.733665" transform="rotate(-0 12.829781 283.733665)">CRNN-CN</text>
-    </g>
-    <g id="patch_133">
-     <path d="M 128.297812 292.698353 
-L 335.566687 292.698353 
-L 335.566687 268.698353 
-L 128.297812 268.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_134">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="283.733665" transform="rotate(-0 149.0247 283.733665)">Text Recognition</text>
-    </g>
-    <g id="patch_134">
-     <path d="M 335.566687 292.698353 
-L 402.168937 292.698353 
-L 402.168937 268.698353 
-L 335.566687 268.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_135">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="283.733665" transform="rotate(-0 342.226912 283.733665)">100x32</text>
-    </g>
-    <g id="patch_135">
-     <path d="M 402.168937 292.698353 
-L 505.524937 292.698353 
-L 505.524937 268.698353 
-L 402.168937 268.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_136">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="283.733665" transform="rotate(-0 412.504537 283.733665)">23.07</text>
-    </g>
-    <g id="patch_136">
-     <path d="M 505.524937 292.698353 
-L 592.378875 292.698353 
-L 592.378875 268.698353 
-L 505.524937 268.698353 
-z
-" style="fill: #15904c; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_137">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="283.733665" transform="rotate(-0 514.210331 283.733665)">297.48</text>
-    </g>
-    <g id="patch_137">
-     <path d="M 592.378875 292.698353 
-L 709.27725 292.698353 
-L 709.27725 268.698353 
-L 592.378875 268.698353 
-z
-" style="fill: #fdbd6d; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_138">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="283.733665" transform="rotate(-0 604.068712 283.733665)">2244.03</text>
-    </g>
-    <g id="patch_138">
-     <path d="M 709.27725 292.698353 
-L 809.53125 292.698353 
-L 809.53125 268.698353 
-L 709.27725 268.698353 
-z
-" style="fill: #04703b; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_139">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="283.733665" transform="rotate(-0 719.30265 283.733665)">82.93</text>
-    </g>
-    <g id="patch_139">
-     <path d="M 809.53125 292.698353 
-L 911.107312 292.698353 
-L 911.107312 268.698353 
-L 809.53125 268.698353 
-z
-" style="fill: #39a758; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_140">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="283.733665" transform="rotate(-0 819.688856 283.733665)">495.94</text>
-    </g>
-    <g id="patch_140">
-     <path d="M 911.107312 292.698353 
-L 1002.669937 292.698353 
-L 1002.669937 268.698353 
-L 911.107312 268.698353 
-z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_141">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="283.733665" transform="rotate(-0 920.263575 283.733665)">3330.69</text>
-    </g>
-    <g id="patch_141">
-     <path d="M 1002.669937 292.698353 
-L 1119.195 292.698353 
-L 1119.195 268.698353 
-L 1002.669937 268.698353 
-z
-" style="fill: #108647; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_142">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="283.733665" transform="rotate(-0 1014.322444 283.733665)">239.76</text>
-    </g>
-    <g id="patch_142">
-     <path d="M 1119.195 292.698353 
-L 1211.766187 292.698353 
-L 1211.766187 268.698353 
-L 1119.195 268.698353 
-z
-" style="fill: #0b7d42; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_143">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="283.733665" transform="rotate(-0 1128.452119 283.733665)">166.79</text>
-    </g>
-    <g id="patch_143">
-     <path d="M 1211.766187 292.698353 
-L 1351.182937 292.698353 
-L 1351.182937 268.698353 
-L 1211.766187 268.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_144">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="283.733665" transform="rotate(-0 1225.707862 283.733665)">---</text>
-    </g>
-    <g id="patch_144">
-     <path d="M 1351.182937 292.698353 
-L 1435.57425 292.698353 
-L 1435.57425 268.698353 
-L 1351.182937 268.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_145">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="283.733665" transform="rotate(-0 1359.622069 283.733665)">---</text>
-    </g>
-    <g id="patch_145">
-     <path d="M 0 316.698353 
-L 128.297812 316.698353 
-L 128.297812 292.698353 
-L 0 292.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_146">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="307.733665" transform="rotate(-0 12.829781 307.733665)">PP-ResNet</text>
-    </g>
-    <g id="patch_146">
-     <path d="M 128.297812 316.698353 
-L 335.566687 316.698353 
-L 335.566687 292.698353 
-L 128.297812 292.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_147">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="307.733665" transform="rotate(-0 149.0247 307.733665)">Image Classification</text>
-    </g>
-    <g id="patch_147">
-     <path d="M 335.566687 316.698353 
-L 402.168937 316.698353 
-L 402.168937 292.698353 
-L 335.566687 292.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_148">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="307.733665" transform="rotate(-0 342.226912 307.733665)">224x224</text>
-    </g>
-    <g id="patch_148">
-     <path d="M 402.168937 316.698353 
-L 505.524937 316.698353 
-L 505.524937 292.698353 
-L 402.168937 292.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_149">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="307.733665" transform="rotate(-0 412.504537 307.733665)">34.71</text>
-    </g>
-    <g id="patch_149">
-     <path d="M 505.524937 316.698353 
-L 592.378875 316.698353 
-L 592.378875 292.698353 
-L 505.524937 292.698353 
-z
-" style="fill: #07753e; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_150">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="307.733665" transform="rotate(-0 514.210331 307.733665)">463.93</text>
-    </g>
-    <g id="patch_150">
-     <path d="M 592.378875 316.698353 
-L 709.27725 316.698353 
-L 709.27725 292.698353 
-L 592.378875 292.698353 
-z
-" style="fill: #f98e52; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_151">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="307.733665" transform="rotate(-0 604.068712 307.733665)">11793.09</text>
-    </g>
-    <g id="patch_151">
-     <path d="M 709.27725 316.698353 
-L 809.53125 316.698353 
-L 809.53125 292.698353 
-L 709.27725 292.698353 
-z
-" style="fill: #026c39; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_152">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="307.733665" transform="rotate(-0 719.30265 307.733665)">178.87</text>
-    </g>
-    <g id="patch_152">
-     <path d="M 809.53125 316.698353 
-L 911.107312 316.698353 
-L 911.107312 292.698353 
-L 809.53125 292.698353 
-z
-" style="fill: #0c7f43; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_153">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="307.733665" transform="rotate(-0 819.688856 307.733665)">759.81</text>
-    </g>
-    <g id="patch_153">
-     <path d="M 911.107312 316.698353 
-L 1002.669937 316.698353 
-L 1002.669937 292.698353 
-L 911.107312 292.698353 
-z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_154">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="307.733665" transform="rotate(-0 920.263575 307.733665)">15753.56</text>
-    </g>
-    <g id="patch_154">
-     <path d="M 1002.669937 316.698353 
-L 1119.195 316.698353 
-L 1119.195 292.698353 
-L 1002.669937 292.698353 
-z
-" style="fill: #016a38; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_155">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="307.733665" transform="rotate(-0 1014.322444 307.733665)">98.64</text>
-    </g>
-    <g id="patch_155">
-     <path d="M 1119.195 316.698353 
-L 1211.766187 316.698353 
-L 1211.766187 292.698353 
-L 1119.195 292.698353 
-z
-" style="fill: #016a38; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_156">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="307.733665" transform="rotate(-0 1128.452119 307.733665)">75.45</text>
-    </g>
-    <g id="patch_156">
-     <path d="M 1211.766187 316.698353 
-L 1351.182937 316.698353 
-L 1351.182937 292.698353 
-L 1211.766187 292.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_157">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="307.733665" transform="rotate(-0 1225.707862 307.733665)">6.99</text>
-    </g>
-    <g id="patch_157">
-     <path d="M 1351.182937 316.698353 
-L 1435.57425 316.698353 
-L 1435.57425 292.698353 
-L 1351.182937 292.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_158">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="307.733665" transform="rotate(-0 1359.622069 307.733665)">---</text>
-    </g>
-    <g id="patch_158">
-     <path d="M 0 340.698353 
-L 128.297812 340.698353 
-L 128.297812 316.698353 
-L 0 316.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_159">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="331.733665" transform="rotate(-0 12.829781 331.733665)">MobileNet-V1</text>
-    </g>
-    <g id="patch_159">
-     <path d="M 128.297812 340.698353 
-L 335.566687 340.698353 
-L 335.566687 316.698353 
-L 128.297812 316.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_160">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="331.733665" transform="rotate(-0 149.0247 331.733665)">Image Classification</text>
-    </g>
-    <g id="patch_160">
-     <path d="M 335.566687 340.698353 
-L 402.168937 340.698353 
-L 402.168937 316.698353 
-L 335.566687 316.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_161">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="331.733665" transform="rotate(-0 342.226912 331.733665)">224x224</text>
-    </g>
-    <g id="patch_161">
-     <path d="M 402.168937 340.698353 
-L 505.524937 340.698353 
-L 505.524937 316.698353 
-L 402.168937 316.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_162">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="331.733665" transform="rotate(-0 412.504537 331.733665)">5.90</text>
-    </g>
-    <g id="patch_162">
-     <path d="M 505.524937 340.698353 
-L 592.378875 340.698353 
-L 592.378875 316.698353 
-L 505.524937 316.698353 
-z
-" style="fill: #08773f; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_163">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="331.733665" transform="rotate(-0 514.210331 331.733665)">72.33</text>
-    </g>
-    <g id="patch_163">
-     <path d="M 592.378875 340.698353 
-L 709.27725 340.698353 
-L 709.27725 316.698353 
-L 592.378875 316.698353 
-z
-" style="fill: #f99355; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_164">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="331.733665" transform="rotate(-0 604.068712 331.733665)">1546.16</text>
-    </g>
-    <g id="patch_164">
-     <path d="M 709.27725 340.698353 
-L 809.53125 340.698353 
-L 809.53125 316.698353 
-L 709.27725 316.698353 
-z
-" style="fill: #036e3a; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_165">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="331.733665" transform="rotate(-0 719.30265 331.733665)">32.78</text>
-    </g>
-    <g id="patch_165">
-     <path d="M 809.53125 340.698353 
-L 911.107312 340.698353 
-L 911.107312 316.698353 
-L 809.53125 316.698353 
-z
-" style="fill: #108647; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_166">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="331.733665" transform="rotate(-0 819.688856 331.733665)">140.60</text>
-    </g>
-    <g id="patch_166">
-     <path d="M 911.107312 340.698353 
-L 1002.669937 340.698353 
-L 1002.669937 316.698353 
-L 911.107312 316.698353 
-z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_167">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="331.733665" transform="rotate(-0 920.263575 331.733665)">2091.13</text>
-    </g>
-    <g id="patch_167">
-     <path d="M 1002.669937 340.698353 
-L 1119.195 340.698353 
-L 1119.195 316.698353 
-L 1002.669937 316.698353 
-z
-" style="fill: #036e3a; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_168">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="331.733665" transform="rotate(-0 1014.322444 331.733665)">33.18</text>
-    </g>
-    <g id="patch_168">
-     <path d="M 1119.195 340.698353 
-L 1211.766187 340.698353 
-L 1211.766187 316.698353 
-L 1119.195 316.698353 
-z
-" style="fill: #118848; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_169">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="331.733665" transform="rotate(-0 1128.452119 331.733665)">145.66\*</text>
-    </g>
-    <g id="patch_169">
-     <path d="M 1211.766187 340.698353 
-L 1351.182937 340.698353 
-L 1351.182937 316.698353 
-L 1211.766187 316.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_170">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="331.733665" transform="rotate(-0 1225.707862 331.733665)">5.15</text>
-    </g>
-    <g id="patch_170">
-     <path d="M 1351.182937 340.698353 
-L 1435.57425 340.698353 
-L 1435.57425 316.698353 
-L 1351.182937 316.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_171">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="331.733665" transform="rotate(-0 1359.622069 331.733665)">---</text>
-    </g>
-    <g id="patch_171">
-     <path d="M 0 364.698353 
-L 128.297812 364.698353 
-L 128.297812 340.698353 
-L 0 340.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_172">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="355.733665" transform="rotate(-0 12.829781 355.733665)">MobileNet-V2</text>
-    </g>
-    <g id="patch_172">
-     <path d="M 128.297812 364.698353 
-L 335.566687 364.698353 
-L 335.566687 340.698353 
-L 128.297812 340.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_173">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="355.733665" transform="rotate(-0 149.0247 355.733665)">Image Classification</text>
-    </g>
-    <g id="patch_173">
-     <path d="M 335.566687 364.698353 
-L 402.168937 364.698353 
-L 402.168937 340.698353 
-L 335.566687 340.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_174">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="355.733665" transform="rotate(-0 342.226912 355.733665)">224x224</text>
-    </g>
-    <g id="patch_174">
-     <path d="M 402.168937 364.698353 
-L 505.524937 364.698353 
-L 505.524937 340.698353 
-L 402.168937 340.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_175">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="355.733665" transform="rotate(-0 412.504537 355.733665)">5.97</text>
-    </g>
-    <g id="patch_175">
-     <path d="M 505.524937 364.698353 
-L 592.378875 364.698353 
-L 592.378875 340.698353 
-L 505.524937 340.698353 
-z
-" style="fill: #097940; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_176">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="355.733665" transform="rotate(-0 514.210331 355.733665)">66.56</text>
-    </g>
-    <g id="patch_176">
-     <path d="M 592.378875 364.698353 
-L 709.27725 364.698353 
-L 709.27725 340.698353 
-L 592.378875 340.698353 
+     <path d="M 982.407937 273.498353 
+L 1071.918375 273.498353 
+L 1071.918375 249.498353 
+L 982.407937 249.498353 
 z
 " style="fill: #fa9656; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_177">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="355.733665" transform="rotate(-0 604.068712 355.733665)">1166.56</text>
+    <g id="text_132">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="264.533665" transform="rotate(-0 991.358981 264.533665)">1089.94</text>
     </g>
-    <g id="patch_177">
-     <path d="M 709.27725 364.698353 
-L 809.53125 364.698353 
-L 809.53125 340.698353 
-L 709.27725 340.698353 
+    <g id="patch_132">
+     <path d="M 1071.918375 273.498353 
+L 1168.705313 273.498353 
+L 1168.705313 249.498353 
+L 1071.918375 249.498353 
 z
-" style="fill: #036e3a; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #fdb365; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_178">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="355.733665" transform="rotate(-0 719.30265 355.733665)">28.38</text>
+    <g id="text_133">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="264.533665" transform="rotate(-0 1081.597069 264.533665)">961.44</text>
     </g>
-    <g id="patch_178">
-     <path d="M 809.53125 364.698353 
-L 911.107312 364.698353 
-L 911.107312 340.698353 
-L 809.53125 340.698353 
+    <g id="patch_133">
+     <path d="M 1168.705313 273.498353 
+L 1264.448625 273.498353 
+L 1264.448625 249.498353 
+L 1168.705313 249.498353 
 z
-" style="fill: #138c4a; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #e65036; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_179">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="355.733665" transform="rotate(-0 819.688856 355.733665)">122.53</text>
+    <g id="text_134">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="264.533665" transform="rotate(-0 1178.279644 264.533665)">1433.26</text>
     </g>
-    <g id="patch_179">
-     <path d="M 911.107312 364.698353 
-L 1002.669937 364.698353 
-L 1002.669937 340.698353 
-L 911.107312 340.698353 
+    <g id="patch_134">
+     <path d="M 1264.448625 273.498353 
+L 1353.959063 273.498353 
+L 1353.959063 249.498353 
+L 1264.448625 249.498353 
 z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #cfeb85; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_180">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="355.733665" transform="rotate(-0 920.263575 355.733665)">1583.25</text>
+    <g id="text_135">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="264.533665" transform="rotate(-0 1273.399669 264.533665)">302.58</text>
     </g>
-    <g id="patch_180">
-     <path d="M 1002.669937 364.698353 
-L 1119.195 364.698353 
-L 1119.195 340.698353 
-L 1002.669937 340.698353 
+    <g id="patch_135">
+     <path d="M 1353.959063 273.498353 
+L 1450.746 273.498353 
+L 1450.746 249.498353 
+L 1353.959063 249.498353 
 z
-" style="fill: #04703b; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_181">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="355.733665" transform="rotate(-0 1014.322444 355.733665)">31.92</text>
+    <g id="text_136">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="264.533665" transform="rotate(-0 1363.637756 264.533665)">---</text>
     </g>
-    <g id="patch_181">
-     <path d="M 1119.195 364.698353 
-L 1211.766187 364.698353 
-L 1211.766187 340.698353 
-L 1119.195 340.698353 
-z
-" style="fill: #16914d; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_182">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="355.733665" transform="rotate(-0 1128.452119 355.733665)">146.31\*</text>
-    </g>
-    <g id="patch_182">
-     <path d="M 1211.766187 364.698353 
-L 1351.182937 364.698353 
-L 1351.182937 340.698353 
-L 1211.766187 340.698353 
+    <g id="patch_136">
+     <path d="M 1450.746 273.498353 
+L 1546.489312 273.498353 
+L 1546.489312 249.498353 
+L 1450.746 249.498353 
 z
 " style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_137">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="264.533665" transform="rotate(-0 1460.320331 264.533665)">17.95</text>
+    </g>
+    <g id="patch_137">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/text_recognition_crnn">
+      <path d="M 0 297.498353 
+L 128.297812 297.498353 
+L 128.297812 273.498353 
+L 0 273.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
+    <g id="text_138">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/text_recognition_crnn">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="288.533665" transform="rotate(-0 12.829781 288.533665)">CRNN-EN</text>
+     </a>
+    </g>
+    <g id="patch_138">
+     <path d="M 128.297812 297.498353 
+L 335.566688 297.498353 
+L 335.566688 273.498353 
+L 128.297812 273.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_139">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="288.533665" transform="rotate(-0 149.0247 288.533665)">Text Recognition</text>
+    </g>
+    <g id="patch_139">
+     <path d="M 335.566688 297.498353 
+L 410.291063 297.498353 
+L 410.291063 273.498353 
+L 335.566688 273.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_140">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="288.533665" transform="rotate(-0 343.039125 288.533665)">100*32</text>
+    </g>
+    <g id="patch_140">
+     <path d="M 410.291063 297.498353 
+L 466.440562 297.498353 
+L 466.440562 273.498353 
+L 410.291063 273.498353 
+z
+" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_141">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="288.533665" transform="rotate(-0 415.906013 288.533665)">20.43</text>
+    </g>
+    <g id="patch_141">
+     <path d="M 466.440562 297.498353 
+L 576.029438 297.498353 
+L 576.029438 273.498353 
+L 466.440562 273.498353 
+z
+" style="fill: #c3e67d; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_142">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="288.533665" transform="rotate(-0 477.39945 288.533665)">271.57</text>
+    </g>
+    <g id="patch_142">
+     <path d="M 576.029438 297.498353 
+L 639.014063 297.498353 
+L 639.014063 273.498353 
+L 576.029438 273.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_143">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="288.533665" transform="rotate(-0 582.3279 288.533665)">2230.12</text>
+    </g>
+    <g id="patch_143">
+     <path d="M 639.014063 297.498353 
+L 744.40575 297.498353 
+L 744.40575 273.498353 
+L 639.014063 273.498353 
+z
+" style="fill: #4eb15d; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_144">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="288.533665" transform="rotate(-0 649.553231 288.533665)">77.51</text>
+    </g>
+    <g id="patch_144">
+     <path d="M 744.40575 297.498353 
+L 881.238187 297.498353 
+L 881.238187 273.498353 
+L 744.40575 273.498353 
+z
+" style="fill: #f5fbb2; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_145">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="288.533665" transform="rotate(-0 758.088994 288.533665)">464.58</text>
+    </g>
+    <g id="patch_145">
+     <path d="M 881.238187 297.498353 
+L 982.407937 297.498353 
+L 982.407937 273.498353 
+L 881.238187 273.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_146">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="288.533665" transform="rotate(-0 891.355163 288.533665)">3277.07</text>
+    </g>
+    <g id="patch_146">
+     <path d="M 982.407937 297.498353 
+L 1071.918375 297.498353 
+L 1071.918375 273.498353 
+L 982.407937 273.498353 
+z
+" style="fill: #c1e57b; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_147">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="288.533665" transform="rotate(-0 991.358981 288.533665)">269.52</text>
+    </g>
+    <g id="patch_147">
+     <path d="M 1071.918375 297.498353 
+L 1168.705313 297.498353 
+L 1168.705313 273.498353 
+L 1071.918375 273.498353 
+z
+" style="fill: #a7d96b; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_148">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="288.533665" transform="rotate(-0 1081.597069 288.533665)">199.81</text>
+    </g>
+    <g id="patch_148">
+     <path d="M 1168.705313 297.498353 
+L 1264.448625 297.498353 
+L 1264.448625 273.498353 
+L 1168.705313 273.498353 
+z
+" style="fill: #cdea83; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_149">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="288.533665" transform="rotate(-0 1178.279644 288.533665)">303.65</text>
+    </g>
+    <g id="patch_149">
+     <path d="M 1264.448625 297.498353 
+L 1353.959063 297.498353 
+L 1353.959063 273.498353 
+L 1264.448625 273.498353 
+z
+" style="fill: #219c52; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_150">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="288.533665" transform="rotate(-0 1273.399669 288.533665)">45.60</text>
+    </g>
+    <g id="patch_150">
+     <path d="M 1353.959063 297.498353 
+L 1450.746 297.498353 
+L 1450.746 273.498353 
+L 1353.959063 273.498353 
+z
+" style="fill: #96d268; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_151">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="288.533665" transform="rotate(-0 1363.637756 288.533665)">172.06</text>
+    </g>
+    <g id="patch_151">
+     <path d="M 1450.746 297.498353 
+L 1546.489312 297.498353 
+L 1546.489312 273.498353 
+L 1450.746 273.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_152">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="288.533665" transform="rotate(-0 1460.320331 288.533665)">---</text>
+    </g>
+    <g id="patch_152">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/text_recognition_crnn">
+      <path d="M 0 321.498353 
+L 128.297812 321.498353 
+L 128.297812 297.498353 
+L 0 297.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
+    <g id="text_153">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/text_recognition_crnn">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="312.533665" transform="rotate(-0 12.829781 312.533665)">CRNN-CN</text>
+     </a>
+    </g>
+    <g id="patch_153">
+     <path d="M 128.297812 321.498353 
+L 335.566688 321.498353 
+L 335.566688 297.498353 
+L 128.297812 297.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_154">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="312.533665" transform="rotate(-0 149.0247 312.533665)">Text Recognition</text>
+    </g>
+    <g id="patch_154">
+     <path d="M 335.566688 321.498353 
+L 410.291063 321.498353 
+L 410.291063 297.498353 
+L 335.566688 297.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_155">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="312.533665" transform="rotate(-0 343.039125 312.533665)">100*32</text>
+    </g>
+    <g id="patch_155">
+     <path d="M 410.291063 321.498353 
+L 466.440562 321.498353 
+L 466.440562 297.498353 
+L 410.291063 297.498353 
+z
+" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_156">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="312.533665" transform="rotate(-0 415.906013 312.533665)">23.08</text>
+    </g>
+    <g id="patch_156">
+     <path d="M 466.440562 321.498353 
+L 576.029438 321.498353 
+L 576.029438 297.498353 
+L 466.440562 297.498353 
+z
+" style="fill: #c9e881; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_157">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="312.533665" transform="rotate(-0 477.39945 312.533665)">293.83</text>
+    </g>
+    <g id="patch_157">
+     <path d="M 576.029438 321.498353 
+L 639.014063 321.498353 
+L 639.014063 297.498353 
+L 576.029438 297.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_158">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="312.533665" transform="rotate(-0 582.3279 312.533665)">2244.03</text>
+    </g>
+    <g id="patch_158">
+     <path d="M 639.014063 321.498353 
+L 744.40575 321.498353 
+L 744.40575 297.498353 
+L 639.014063 297.498353 
+z
+" style="fill: #51b35e; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_159">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="312.533665" transform="rotate(-0 649.553231 312.533665)">82.93</text>
+    </g>
+    <g id="patch_159">
+     <path d="M 744.40575 321.498353 
+L 881.238187 321.498353 
+L 881.238187 297.498353 
+L 744.40575 297.498353 
+z
+" style="fill: #fbfdba; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_160">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="312.533665" transform="rotate(-0 758.088994 312.533665)">495.94</text>
+    </g>
+    <g id="patch_160">
+     <path d="M 881.238187 321.498353 
+L 982.407937 321.498353 
+L 982.407937 297.498353 
+L 881.238187 297.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_161">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="312.533665" transform="rotate(-0 891.355163 312.533665)">3330.69</text>
+    </g>
+    <g id="patch_161">
+     <path d="M 982.407937 321.498353 
+L 1071.918375 321.498353 
+L 1071.918375 297.498353 
+L 982.407937 297.498353 
+z
+" style="fill: #c9e881; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_162">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="312.533665" transform="rotate(-0 991.358981 312.533665)">290.82</text>
+    </g>
+    <g id="patch_162">
+     <path d="M 1071.918375 321.498353 
+L 1168.705313 321.498353 
+L 1168.705313 297.498353 
+L 1071.918375 297.498353 
+z
+" style="fill: #addc6f; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_163">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="312.533665" transform="rotate(-0 1081.597069 312.533665)">217.07</text>
+    </g>
+    <g id="patch_163">
+     <path d="M 1168.705313 321.498353 
+L 1264.448625 321.498353 
+L 1264.448625 297.498353 
+L 1168.705313 297.498353 
+z
+" style="fill: #d5ed88; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_164">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="312.533665" transform="rotate(-0 1178.279644 312.533665)">329.84</text>
+    </g>
+    <g id="patch_164">
+     <path d="M 1264.448625 321.498353 
+L 1353.959063 321.498353 
+L 1353.959063 297.498353 
+L 1264.448625 297.498353 
+z
+" style="fill: #33a456; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_165">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="312.533665" transform="rotate(-0 1273.399669 312.533665)">59.39</text>
+    </g>
+    <g id="patch_165">
+     <path d="M 1353.959063 321.498353 
+L 1450.746 321.498353 
+L 1450.746 297.498353 
+L 1353.959063 297.498353 
+z
+" style="fill: #9bd469; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_166">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="312.533665" transform="rotate(-0 1363.637756 312.533665)">183.51</text>
+    </g>
+    <g id="patch_166">
+     <path d="M 1450.746 321.498353 
+L 1546.489312 321.498353 
+L 1546.489312 297.498353 
+L 1450.746 297.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_167">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="312.533665" transform="rotate(-0 1460.320331 312.533665)">---</text>
+    </g>
+    <g id="patch_167">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/image_classification_ppresnet">
+      <path d="M 0 345.498353 
+L 128.297812 345.498353 
+L 128.297812 321.498353 
+L 0 321.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
+    <g id="text_168">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/image_classification_ppresnet">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="336.533665" transform="rotate(-0 12.829781 336.533665)">PP-ResNet</text>
+     </a>
+    </g>
+    <g id="patch_168">
+     <path d="M 128.297812 345.498353 
+L 335.566688 345.498353 
+L 335.566688 321.498353 
+L 128.297812 321.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_169">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="336.533665" transform="rotate(-0 149.0247 336.533665)">Image Classification</text>
+    </g>
+    <g id="patch_169">
+     <path d="M 335.566688 345.498353 
+L 410.291063 345.498353 
+L 410.291063 321.498353 
+L 335.566688 321.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_170">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="336.533665" transform="rotate(-0 343.039125 336.533665)">224x224</text>
+    </g>
+    <g id="patch_170">
+     <path d="M 410.291063 345.498353 
+L 466.440562 345.498353 
+L 466.440562 321.498353 
+L 410.291063 321.498353 
+z
+" style="fill: #4eb15d; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_171">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="336.533665" transform="rotate(-0 415.906013 336.533665)">35.40</text>
+    </g>
+    <g id="patch_171">
+     <path d="M 466.440562 345.498353 
+L 576.029438 345.498353 
+L 576.029438 321.498353 
+L 466.440562 321.498353 
+z
+" style="fill: #fa9656; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_172">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="336.533665" transform="rotate(-0 477.39945 336.533665)">547.70</text>
+    </g>
+    <g id="patch_172">
+     <path d="M 576.029438 345.498353 
+L 639.014063 345.498353 
+L 639.014063 321.498353 
+L 576.029438 321.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_173">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="336.533665" transform="rotate(-0 582.3279 336.533665)">11793.09</text>
+    </g>
+    <g id="patch_173">
+     <path d="M 639.014063 345.498353 
+L 744.40575 345.498353 
+L 744.40575 321.498353 
+L 639.014063 321.498353 
+z
+" style="fill: #dff293; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_174">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="336.533665" transform="rotate(-0 649.553231 336.533665)">178.87</text>
+    </g>
+    <g id="patch_174">
+     <path d="M 744.40575 345.498353 
+L 881.238187 345.498353 
+L 881.238187 321.498353 
+L 744.40575 321.498353 
+z
+" style="fill: #e0422f; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_175">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="336.533665" transform="rotate(-0 758.088994 336.533665)">759.81</text>
+    </g>
+    <g id="patch_175">
+     <path d="M 881.238187 345.498353 
+L 982.407937 345.498353 
+L 982.407937 321.498353 
+L 881.238187 321.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_176">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="336.533665" transform="rotate(-0 891.355163 336.533665)">15753.56</text>
+    </g>
+    <g id="patch_176">
+     <path d="M 982.407937 345.498353 
+L 1071.918375 345.498353 
+L 1071.918375 321.498353 
+L 982.407937 321.498353 
+z
+" style="fill: #feda86; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_177">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="336.533665" transform="rotate(-0 991.358981 336.533665)">376.88</text>
+    </g>
+    <g id="patch_177">
+     <path d="M 1071.918375 345.498353 
+L 1168.705313 345.498353 
+L 1168.705313 321.498353 
+L 1071.918375 321.498353 
+z
+" style="fill: #fed683; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_178">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="336.533665" transform="rotate(-0 1081.597069 336.533665)">385.29</text>
+    </g>
+    <g id="patch_178">
+     <path d="M 1168.705313 345.498353 
+L 1264.448625 345.498353 
+L 1264.448625 321.498353 
+L 1168.705313 321.498353 
+z
+" style="fill: #f98e52; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_179">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="336.533665" transform="rotate(-0 1178.279644 336.533665)">564.69</text>
+    </g>
+    <g id="patch_179">
+     <path d="M 1264.448625 345.498353 
+L 1353.959063 345.498353 
+L 1353.959063 321.498353 
+L 1264.448625 321.498353 
+z
+" style="fill: #cdea83; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_180">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="336.533665" transform="rotate(-0 1273.399669 336.533665)">148.58</text>
+    </g>
+    <g id="patch_180">
+     <path d="M 1353.959063 345.498353 
+L 1450.746 345.498353 
+L 1450.746 321.498353 
+L 1353.959063 321.498353 
+z
+" style="fill: #fee695; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_181">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="336.533665" transform="rotate(-0 1363.637756 336.533665)">340.20</text>
+    </g>
+    <g id="patch_181">
+     <path d="M 1450.746 345.498353 
+L 1546.489312 345.498353 
+L 1546.489312 321.498353 
+L 1450.746 321.498353 
+z
+" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_182">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="336.533665" transform="rotate(-0 1460.320331 336.533665)">6.99</text>
+    </g>
+    <g id="patch_182">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/image_classification_mobilenet">
+      <path d="M 0 369.498353 
+L 128.297812 369.498353 
+L 128.297812 345.498353 
+L 0 345.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
     <g id="text_183">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="355.733665" transform="rotate(-0 1225.707862 355.733665)">5.41</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/image_classification_mobilenet">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="360.533665" transform="rotate(-0 12.829781 360.533665)">MobileNet-V1</text>
+     </a>
     </g>
     <g id="patch_183">
-     <path d="M 1351.182937 364.698353 
-L 1435.57425 364.698353 
-L 1435.57425 340.698353 
-L 1351.182937 340.698353 
+     <path d="M 128.297812 369.498353 
+L 335.566688 369.498353 
+L 335.566688 345.498353 
+L 128.297812 345.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_184">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="355.733665" transform="rotate(-0 1359.622069 355.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="360.533665" transform="rotate(-0 149.0247 360.533665)">Image Classification</text>
     </g>
     <g id="patch_184">
-     <path d="M 0 388.698353 
-L 128.297812 388.698353 
-L 128.297812 364.698353 
-L 0 364.698353 
+     <path d="M 335.566688 369.498353 
+L 410.291063 369.498353 
+L 410.291063 345.498353 
+L 335.566688 345.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_185">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="379.733665" transform="rotate(-0 12.829781 379.733665)">PP-HumanSeg</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="360.533665" transform="rotate(-0 343.039125 360.533665)">224x224</text>
     </g>
     <g id="patch_185">
-     <path d="M 128.297812 388.698353 
-L 335.566687 388.698353 
-L 335.566687 364.698353 
-L 128.297812 364.698353 
+     <path d="M 410.291063 369.498353 
+L 466.440562 369.498353 
+L 466.440562 345.498353 
+L 410.291063 345.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #0c7f43; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_186">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="379.733665" transform="rotate(-0 149.0247 379.733665)">Human Segmentation</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="360.533665" transform="rotate(-0 415.906013 360.533665)">6.25</text>
     </g>
     <g id="patch_186">
-     <path d="M 335.566687 388.698353 
-L 402.168937 388.698353 
-L 402.168937 364.698353 
-L 335.566687 364.698353 
+     <path d="M 466.440562 369.498353 
+L 576.029438 369.498353 
+L 576.029438 345.498353 
+L 466.440562 345.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #cbe982; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_187">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="379.733665" transform="rotate(-0 342.226912 379.733665)">192x192</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="360.533665" transform="rotate(-0 477.39945 360.533665)">74.51</text>
     </g>
     <g id="patch_187">
-     <path d="M 402.168937 388.698353 
-L 505.524937 388.698353 
-L 505.524937 364.698353 
-L 402.168937 364.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_188">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="379.733665" transform="rotate(-0 412.504537 379.733665)">8.81</text>
-    </g>
-    <g id="patch_188">
-     <path d="M 505.524937 388.698353 
-L 592.378875 388.698353 
-L 592.378875 364.698353 
-L 505.524937 364.698353 
-z
-" style="fill: #07753e; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_189">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="379.733665" transform="rotate(-0 514.210331 379.733665)">73.13</text>
-    </g>
-    <g id="patch_189">
-     <path d="M 592.378875 388.698353 
-L 709.27725 388.698353 
-L 709.27725 364.698353 
-L 592.378875 364.698353 
-z
-" style="fill: #f99153; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_190">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="379.733665" transform="rotate(-0 604.068712 379.733665)">1610.78</text>
-    </g>
-    <g id="patch_190">
-     <path d="M 709.27725 388.698353 
-L 809.53125 388.698353 
-L 809.53125 364.698353 
-L 709.27725 364.698353 
-z
-" style="fill: #036e3a; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_191">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="379.733665" transform="rotate(-0 719.30265 379.733665)">34.58</text>
-    </g>
-    <g id="patch_191">
-     <path d="M 809.53125 388.698353 
-L 911.107312 388.698353 
-L 911.107312 364.698353 
-L 809.53125 364.698353 
-z
-" style="fill: #108647; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_192">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="379.733665" transform="rotate(-0 819.688856 379.733665)">144.23</text>
-    </g>
-    <g id="patch_192">
-     <path d="M 911.107312 388.698353 
-L 1002.669937 388.698353 
-L 1002.669937 364.698353 
-L 911.107312 364.698353 
+     <path d="M 576.029438 369.498353 
+L 639.014063 369.498353 
+L 639.014063 345.498353 
+L 576.029438 345.498353 
 z
 " style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_188">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="360.533665" transform="rotate(-0 582.3279 360.533665)">1546.16</text>
+    </g>
+    <g id="patch_188">
+     <path d="M 639.014063 369.498353 
+L 744.40575 369.498353 
+L 744.40575 345.498353 
+L 639.014063 345.498353 
+z
+" style="fill: #7dc765; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_189">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="360.533665" transform="rotate(-0 649.553231 360.533665)">32.78</text>
+    </g>
+    <g id="patch_189">
+     <path d="M 744.40575 369.498353 
+L 881.238187 369.498353 
+L 881.238187 345.498353 
+L 744.40575 345.498353 
+z
+" style="fill: #fff8b4; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_190">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="360.533665" transform="rotate(-0 758.088994 360.533665)">140.60</text>
+    </g>
+    <g id="patch_190">
+     <path d="M 881.238187 369.498353 
+L 982.407937 369.498353 
+L 982.407937 345.498353 
+L 881.238187 345.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_191">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="360.533665" transform="rotate(-0 891.355163 360.533665)">2091.13</text>
+    </g>
+    <g id="patch_191">
+     <path d="M 982.407937 369.498353 
+L 1071.918375 369.498353 
+L 1071.918375 345.498353 
+L 982.407937 345.498353 
+z
+" style="fill: #c3e67d; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_192">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="360.533665" transform="rotate(-0 991.358981 360.533665)">68.94</text>
+    </g>
+    <g id="patch_192">
+     <path d="M 1071.918375 369.498353 
+L 1168.705313 369.498353 
+L 1168.705313 345.498353 
+L 1071.918375 345.498353 
+z
+" style="fill: #bde379; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
     <g id="text_193">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="379.733665" transform="rotate(-0 920.263575 379.733665)">2157.86</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="360.533665" transform="rotate(-0 1081.597069 360.533665)">64.73</text>
     </g>
     <g id="patch_193">
-     <path d="M 1002.669937 388.698353 
-L 1119.195 388.698353 
-L 1119.195 364.698353 
-L 1002.669937 364.698353 
+     <path d="M 1168.705313 369.498353 
+L 1264.448625 369.498353 
+L 1264.448625 345.498353 
+L 1168.705313 345.498353 
 z
-" style="fill: #07753e; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ebf7a3; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_194">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="379.733665" transform="rotate(-0 1014.322444 379.733665)">67.97</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="360.533665" transform="rotate(-0 1178.279644 360.533665)">103.96</text>
     </g>
     <g id="patch_194">
-     <path d="M 1119.195 388.698353 
-L 1211.766187 388.698353 
-L 1211.766187 364.698353 
-L 1119.195 364.698353 
+     <path d="M 1264.448625 369.498353 
+L 1353.959063 369.498353 
+L 1353.959063 345.498353 
+L 1264.448625 345.498353 
 z
-" style="fill: #08773f; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #c5e67e; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_195">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="379.733665" transform="rotate(-0 1128.452119 379.733665)">74.77</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="360.533665" transform="rotate(-0 1273.399669 360.533665)">69.24</text>
     </g>
     <g id="patch_195">
-     <path d="M 1211.766187 388.698353 
-L 1351.182937 388.698353 
-L 1351.182937 364.698353 
-L 1211.766187 364.698353 
+     <path d="M 1353.959063 369.498353 
+L 1450.746 369.498353 
+L 1450.746 345.498353 
+L 1353.959063 345.498353 
+z
+" style="fill: #b7e075; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_196">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="360.533665" transform="rotate(-0 1363.637756 360.533665)">60.75\*</text>
+    </g>
+    <g id="patch_196">
+     <path d="M 1450.746 369.498353 
+L 1546.489312 369.498353 
+L 1546.489312 345.498353 
+L 1450.746 345.498353 
 z
 " style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_196">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="379.733665" transform="rotate(-0 1225.707862 379.733665)">6.94</text>
-    </g>
-    <g id="patch_196">
-     <path d="M 1351.182937 388.698353 
-L 1435.57425 388.698353 
-L 1435.57425 364.698353 
-L 1351.182937 364.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
     <g id="text_197">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="379.733665" transform="rotate(-0 1359.622069 379.733665)">---</text>
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="360.533665" transform="rotate(-0 1460.320331 360.533665)">5.15</text>
     </g>
     <g id="patch_197">
-     <path d="M 0 412.698353 
-L 128.297812 412.698353 
-L 128.297812 388.698353 
-L 0 388.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/image_classification_mobilenet">
+      <path d="M 0 393.498353 
+L 128.297812 393.498353 
+L 128.297812 369.498353 
+L 0 369.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_198">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="403.733665" transform="rotate(-0 12.829781 403.733665)">WeChatQRCode</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/image_classification_mobilenet">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="384.533665" transform="rotate(-0 12.829781 384.533665)">MobileNet-V2</text>
+     </a>
     </g>
     <g id="patch_198">
-     <path d="M 128.297812 412.698353 
-L 335.566687 412.698353 
-L 335.566687 388.698353 
-L 128.297812 388.698353 
+     <path d="M 128.297812 393.498353 
+L 335.566688 393.498353 
+L 335.566688 369.498353 
+L 128.297812 369.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_199">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="403.733665" transform="rotate(-0 149.0247 403.733665)">QR Code Detection and Parsing</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="384.533665" transform="rotate(-0 149.0247 384.533665)">Image Classification</text>
     </g>
     <g id="patch_199">
-     <path d="M 335.566687 412.698353 
-L 402.168937 412.698353 
-L 402.168937 388.698353 
-L 335.566687 388.698353 
+     <path d="M 335.566688 393.498353 
+L 410.291063 393.498353 
+L 410.291063 369.498353 
+L 335.566688 369.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_200">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="403.733665" transform="rotate(-0 342.226912 403.733665)">100x100</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="384.533665" transform="rotate(-0 343.039125 384.533665)">224x224</text>
     </g>
     <g id="patch_200">
-     <path d="M 402.168937 412.698353 
-L 505.524937 412.698353 
-L 505.524937 388.698353 
-L 402.168937 388.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_201">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="403.733665" transform="rotate(-0 412.504537 403.733665)">1.29</text>
-    </g>
-    <g id="patch_201">
-     <path d="M 505.524937 412.698353 
-L 592.378875 412.698353 
-L 592.378875 388.698353 
-L 505.524937 388.698353 
-z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_202">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="403.733665" transform="rotate(-0 514.210331 403.733665)">5.71</text>
-    </g>
-    <g id="patch_202">
-     <path d="M 592.378875 412.698353 
-L 709.27725 412.698353 
-L 709.27725 388.698353 
-L 592.378875 388.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_203">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="403.733665" transform="rotate(-0 604.068712 403.733665)">---</text>
-    </g>
-    <g id="patch_203">
-     <path d="M 709.27725 412.698353 
-L 809.53125 412.698353 
-L 809.53125 388.698353 
-L 709.27725 388.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_204">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="403.733665" transform="rotate(-0 719.30265 403.733665)">---</text>
-    </g>
-    <g id="patch_204">
-     <path d="M 809.53125 412.698353 
-L 911.107312 412.698353 
-L 911.107312 388.698353 
-L 809.53125 388.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_205">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="403.733665" transform="rotate(-0 819.688856 403.733665)">---</text>
-    </g>
-    <g id="patch_205">
-     <path d="M 911.107312 412.698353 
-L 1002.669937 412.698353 
-L 1002.669937 388.698353 
-L 911.107312 388.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_206">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="403.733665" transform="rotate(-0 920.263575 403.733665)">---</text>
-    </g>
-    <g id="patch_206">
-     <path d="M 1002.669937 412.698353 
-L 1119.195 412.698353 
-L 1119.195 388.698353 
-L 1002.669937 388.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_207">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="403.733665" transform="rotate(-0 1014.322444 403.733665)">---</text>
-    </g>
-    <g id="patch_207">
-     <path d="M 1119.195 412.698353 
-L 1211.766187 412.698353 
-L 1211.766187 388.698353 
-L 1119.195 388.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_208">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="403.733665" transform="rotate(-0 1128.452119 403.733665)">---</text>
-    </g>
-    <g id="patch_208">
-     <path d="M 1211.766187 412.698353 
-L 1351.182937 412.698353 
-L 1351.182937 388.698353 
-L 1211.766187 388.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_209">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="403.733665" transform="rotate(-0 1225.707862 403.733665)">---</text>
-    </g>
-    <g id="patch_209">
-     <path d="M 1351.182937 412.698353 
-L 1435.57425 412.698353 
-L 1435.57425 388.698353 
-L 1351.182937 388.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_210">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="403.733665" transform="rotate(-0 1359.622069 403.733665)">---</text>
-    </g>
-    <g id="patch_210">
-     <path d="M 0 436.698353 
-L 128.297812 436.698353 
-L 128.297812 412.698353 
-L 0 412.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_211">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="427.733665" transform="rotate(-0 12.829781 427.733665)">DaSiamRPN</text>
-    </g>
-    <g id="patch_211">
-     <path d="M 128.297812 436.698353 
-L 335.566687 436.698353 
-L 335.566687 412.698353 
-L 128.297812 412.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_212">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="427.733665" transform="rotate(-0 149.0247 427.733665)">Object Tracking</text>
-    </g>
-    <g id="patch_212">
-     <path d="M 335.566687 436.698353 
-L 402.168937 436.698353 
-L 402.168937 412.698353 
-L 335.566687 412.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_213">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="427.733665" transform="rotate(-0 342.226912 427.733665)">1280x720</text>
-    </g>
-    <g id="patch_213">
-     <path d="M 402.168937 436.698353 
-L 505.524937 436.698353 
-L 505.524937 412.698353 
-L 402.168937 412.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_214">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="427.733665" transform="rotate(-0 412.504537 427.733665)">29.05</text>
-    </g>
-    <g id="patch_214">
-     <path d="M 505.524937 436.698353 
-L 592.378875 436.698353 
-L 592.378875 412.698353 
-L 505.524937 412.698353 
+     <path d="M 410.291063 393.498353 
+L 466.440562 393.498353 
+L 466.440562 369.498353 
+L 410.291063 369.498353 
 z
 " style="fill: #08773f; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_215">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="427.733665" transform="rotate(-0 514.210331 427.733665)">712.94</text>
+    <g id="text_201">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="384.533665" transform="rotate(-0 415.906013 384.533665)">6.00</text>
     </g>
-    <g id="patch_215">
-     <path d="M 592.378875 436.698353 
-L 709.27725 436.698353 
-L 709.27725 412.698353 
-L 592.378875 412.698353 
+    <g id="patch_201">
+     <path d="M 466.440562 393.498353 
+L 576.029438 393.498353 
+L 576.029438 369.498353 
+L 466.440562 369.498353 
 z
-" style="fill: #f99153; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #c1e57b; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_216">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="427.733665" transform="rotate(-0 604.068712 427.733665)">14738.64</text>
+    <g id="text_202">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="384.533665" transform="rotate(-0 477.39945 384.533665)">67.29</text>
     </g>
-    <g id="patch_216">
-     <path d="M 709.27725 436.698353 
-L 809.53125 436.698353 
-L 809.53125 412.698353 
-L 709.27725 412.698353 
-z
-" style="fill: #016a38; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_217">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="427.733665" transform="rotate(-0 719.30265 427.733665)">152.78</text>
-    </g>
-    <g id="patch_217">
-     <path d="M 809.53125 436.698353 
-L 911.107312 436.698353 
-L 911.107312 412.698353 
-L 809.53125 412.698353 
-z
-" style="fill: #0b7d42; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_218">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="427.733665" transform="rotate(-0 819.688856 427.733665)">929.63</text>
-    </g>
-    <g id="patch_218">
-     <path d="M 911.107312 436.698353 
-L 1002.669937 436.698353 
-L 1002.669937 412.698353 
-L 911.107312 412.698353 
+    <g id="patch_202">
+     <path d="M 576.029438 393.498353 
+L 639.014063 393.498353 
+L 639.014063 369.498353 
+L 576.029438 369.498353 
 z
 " style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
-    <g id="text_219">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="427.733665" transform="rotate(-0 920.263575 427.733665)">19800.14</text>
+    <g id="text_203">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="384.533665" transform="rotate(-0 582.3279 384.533665)">1166.56</text>
     </g>
-    <g id="patch_219">
-     <path d="M 1002.669937 436.698353 
-L 1119.195 436.698353 
-L 1119.195 412.698353 
-L 1002.669937 412.698353 
+    <g id="patch_203">
+     <path d="M 639.014063 393.498353 
+L 744.40575 393.498353 
+L 744.40575 369.498353 
+L 639.014063 369.498353 
+z
+" style="fill: #70c164; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_204">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="384.533665" transform="rotate(-0 649.553231 384.533665)">28.38</text>
+    </g>
+    <g id="patch_204">
+     <path d="M 744.40575 393.498353 
+L 881.238187 393.498353 
+L 881.238187 369.498353 
+L 744.40575 369.498353 
+z
+" style="fill: #fafdb8; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_205">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="384.533665" transform="rotate(-0 758.088994 384.533665)">122.53</text>
+    </g>
+    <g id="patch_205">
+     <path d="M 881.238187 393.498353 
+L 982.407937 393.498353 
+L 982.407937 369.498353 
+L 881.238187 369.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_206">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="384.533665" transform="rotate(-0 891.355163 384.533665)">1583.25</text>
+    </g>
+    <g id="patch_206">
+     <path d="M 982.407937 393.498353 
+L 1071.918375 393.498353 
+L 1071.918375 369.498353 
+L 982.407937 369.498353 
+z
+" style="fill: #b9e176; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_207">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="384.533665" transform="rotate(-0 991.358981 384.533665)">62.12</text>
+    </g>
+    <g id="patch_207">
+     <path d="M 1071.918375 393.498353 
+L 1168.705313 393.498353 
+L 1168.705313 369.498353 
+L 1071.918375 369.498353 
+z
+" style="fill: #b3df72; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_208">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="384.533665" transform="rotate(-0 1081.597069 384.533665)">58.18</text>
+    </g>
+    <g id="patch_208">
+     <path d="M 1168.705313 393.498353 
+L 1264.448625 393.498353 
+L 1264.448625 369.498353 
+L 1168.705313 369.498353 
+z
+" style="fill: #dff293; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_209">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="384.533665" transform="rotate(-0 1178.279644 384.533665)">90.46</text>
+    </g>
+    <g id="patch_209">
+     <path d="M 1264.448625 393.498353 
+L 1353.959063 393.498353 
+L 1353.959063 369.498353 
+L 1264.448625 369.498353 
+z
+" style="fill: #b9e176; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_210">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="384.533665" transform="rotate(-0 1273.399669 384.533665)">62.12</text>
+    </g>
+    <g id="patch_210">
+     <path d="M 1353.959063 393.498353 
+L 1450.746 393.498353 
+L 1450.746 369.498353 
+L 1353.959063 369.498353 
+z
+" style="fill: #b1de71; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_211">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="384.533665" transform="rotate(-0 1363.637756 384.533665)">57.40\*</text>
+    </g>
+    <g id="patch_211">
+     <path d="M 1450.746 393.498353 
+L 1546.489312 393.498353 
+L 1546.489312 369.498353 
+L 1450.746 369.498353 
 z
 " style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_212">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="384.533665" transform="rotate(-0 1460.320331 384.533665)">5.41</text>
+    </g>
+    <g id="patch_212">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/human_segmentation_pphumanseg">
+      <path d="M 0 417.498353 
+L 128.297812 417.498353 
+L 128.297812 393.498353 
+L 0 393.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
+    <g id="text_213">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/human_segmentation_pphumanseg">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="408.533665" transform="rotate(-0 12.829781 408.533665)">PP-HumanSeg</text>
+     </a>
+    </g>
+    <g id="patch_213">
+     <path d="M 128.297812 417.498353 
+L 335.566688 417.498353 
+L 335.566688 393.498353 
+L 128.297812 393.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_214">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="408.533665" transform="rotate(-0 149.0247 408.533665)">Human Segmentation</text>
+    </g>
+    <g id="patch_214">
+     <path d="M 335.566688 417.498353 
+L 410.291063 417.498353 
+L 410.291063 393.498353 
+L 335.566688 393.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_215">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="408.533665" transform="rotate(-0 343.039125 408.533665)">192x192</text>
+    </g>
+    <g id="patch_215">
+     <path d="M 410.291063 417.498353 
+L 466.440562 417.498353 
+L 466.440562 393.498353 
+L 410.291063 393.498353 
+z
+" style="fill: #0a7b41; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_216">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="408.533665" transform="rotate(-0 415.906013 408.533665)">8.20</text>
+    </g>
+    <g id="patch_216">
+     <path d="M 466.440562 417.498353 
+L 576.029438 417.498353 
+L 576.029438 393.498353 
+L 466.440562 393.498353 
+z
+" style="fill: #abdb6d; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_217">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="408.533665" transform="rotate(-0 477.39945 408.533665)">73.29</text>
+    </g>
+    <g id="patch_217">
+     <path d="M 576.029438 417.498353 
+L 639.014063 417.498353 
+L 639.014063 393.498353 
+L 576.029438 393.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_218">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="408.533665" transform="rotate(-0 582.3279 408.533665)">1610.78</text>
+    </g>
+    <g id="patch_218">
+     <path d="M 639.014063 417.498353 
+L 744.40575 417.498353 
+L 744.40575 393.498353 
+L 639.014063 393.498353 
+z
+" style="fill: #66bd63; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_219">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="408.533665" transform="rotate(-0 649.553231 408.533665)">34.58</text>
+    </g>
+    <g id="patch_219">
+     <path d="M 744.40575 417.498353 
+L 881.238187 417.498353 
+L 881.238187 393.498353 
+L 744.40575 393.498353 
+z
+" style="fill: #e9f6a1; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
     <g id="text_220">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="427.733665" transform="rotate(-0 1014.322444 427.733665)">76.82</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="408.533665" transform="rotate(-0 758.088994 408.533665)">144.23</text>
     </g>
     <g id="patch_220">
-     <path d="M 1119.195 436.698353 
-L 1211.766187 436.698353 
-L 1211.766187 412.698353 
-L 1119.195 412.698353 
+     <path d="M 881.238187 417.498353 
+L 982.407937 417.498353 
+L 982.407937 393.498353 
+L 881.238187 393.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_221">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="427.733665" transform="rotate(-0 1128.452119 427.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="408.533665" transform="rotate(-0 891.355163 408.533665)">2157.86</text>
     </g>
     <g id="patch_221">
-     <path d="M 1211.766187 436.698353 
-L 1351.182937 436.698353 
-L 1351.182937 412.698353 
-L 1211.766187 412.698353 
+     <path d="M 982.407937 417.498353 
+L 1071.918375 417.498353 
+L 1071.918375 393.498353 
+L 982.407937 393.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a0d669; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_222">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="427.733665" transform="rotate(-0 1225.707862 427.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="408.533665" transform="rotate(-0 991.358981 408.533665)">65.91</text>
     </g>
     <g id="patch_222">
-     <path d="M 1351.182937 436.698353 
-L 1435.57425 436.698353 
-L 1435.57425 412.698353 
-L 1351.182937 412.698353 
+     <path d="M 1071.918375 417.498353 
+L 1168.705313 417.498353 
+L 1168.705313 393.498353 
+L 1071.918375 393.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a7d96b; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_223">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="427.733665" transform="rotate(-0 1359.622069 427.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="408.533665" transform="rotate(-0 1081.597069 408.533665)">70.82</text>
     </g>
     <g id="patch_223">
-     <path d="M 0 460.698353 
-L 128.297812 460.698353 
-L 128.297812 436.698353 
-L 0 436.698353 
+     <path d="M 1168.705313 417.498353 
+L 1264.448625 417.498353 
+L 1264.448625 393.498353 
+L 1168.705313 393.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #cfeb85; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_224">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="451.733665" transform="rotate(-0 12.829781 451.733665)">YoutuReID</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="408.533665" transform="rotate(-0 1178.279644 408.533665)">107.98</text>
     </g>
     <g id="patch_224">
-     <path d="M 128.297812 460.698353 
-L 335.566687 460.698353 
-L 335.566687 436.698353 
-L 128.297812 436.698353 
+     <path d="M 1264.448625 417.498353 
+L 1353.959063 417.498353 
+L 1353.959063 393.498353 
+L 1264.448625 393.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #bfe47a; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_225">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="451.733665" transform="rotate(-0 149.0247 451.733665)">Person Re-Identification</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="408.533665" transform="rotate(-0 1273.399669 408.533665)">90.86</text>
     </g>
     <g id="patch_225">
-     <path d="M 335.566687 460.698353 
-L 402.168937 460.698353 
-L 402.168937 436.698353 
-L 335.566687 436.698353 
+     <path d="M 1353.959063 417.498353 
+L 1450.746 417.498353 
+L 1450.746 393.498353 
+L 1353.959063 393.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_226">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="451.733665" transform="rotate(-0 342.226912 451.733665)">128x256</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="408.533665" transform="rotate(-0 1363.637756 408.533665)">---</text>
     </g>
     <g id="patch_226">
-     <path d="M 402.168937 460.698353 
-L 505.524937 460.698353 
-L 505.524937 436.698353 
-L 402.168937 436.698353 
+     <path d="M 1450.746 417.498353 
+L 1546.489312 417.498353 
+L 1546.489312 393.498353 
+L 1450.746 393.498353 
 z
 " style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_227">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="451.733665" transform="rotate(-0 412.504537 451.733665)">30.39</text>
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="408.533665" transform="rotate(-0 1460.320331 408.533665)">6.94</text>
     </g>
     <g id="patch_227">
-     <path d="M 505.524937 460.698353 
-L 592.378875 460.698353 
-L 592.378875 436.698353 
-L 505.524937 436.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/qrcode_wechatqrcode">
+      <path d="M 0 441.498353 
+L 128.297812 441.498353 
+L 128.297812 417.498353 
+L 0 417.498353 
 z
-" style="fill: #0a7b41; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_228">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="451.733665" transform="rotate(-0 514.210331 451.733665)">625.56</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/qrcode_wechatqrcode">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="432.533665" transform="rotate(-0 12.829781 432.533665)">WeChatQRCode</text>
+     </a>
     </g>
     <g id="patch_228">
-     <path d="M 592.378875 460.698353 
-L 709.27725 460.698353 
-L 709.27725 436.698353 
-L 592.378875 436.698353 
+     <path d="M 128.297812 441.498353 
+L 335.566688 441.498353 
+L 335.566688 417.498353 
+L 128.297812 417.498353 
 z
-" style="fill: #f98e52; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_229">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="451.733665" transform="rotate(-0 604.068712 451.733665)">11117.07</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="432.533665" transform="rotate(-0 149.0247 432.533665)">QR Code Detection and Parsing</text>
     </g>
     <g id="patch_229">
-     <path d="M 709.27725 460.698353 
-L 809.53125 460.698353 
-L 809.53125 436.698353 
-L 709.27725 436.698353 
+     <path d="M 335.566688 441.498353 
+L 410.291063 441.498353 
+L 410.291063 417.498353 
+L 335.566688 417.498353 
 z
-" style="fill: #036e3a; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_230">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="451.733665" transform="rotate(-0 719.30265 451.733665)">195.67</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="432.533665" transform="rotate(-0 343.039125 432.533665)">100x100</text>
     </g>
     <g id="patch_230">
-     <path d="M 809.53125 460.698353 
-L 911.107312 460.698353 
-L 911.107312 436.698353 
-L 809.53125 436.698353 
+     <path d="M 410.291063 441.498353 
+L 466.440562 441.498353 
+L 466.440562 417.498353 
+L 410.291063 417.498353 
 z
-" style="fill: #0f8446; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_231">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="451.733665" transform="rotate(-0 819.688856 451.733665)">898.23</text>
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="432.533665" transform="rotate(-0 415.906013 432.533665)">1.35</text>
     </g>
     <g id="patch_231">
-     <path d="M 911.107312 460.698353 
-L 1002.669937 460.698353 
-L 1002.669937 436.698353 
-L 911.107312 436.698353 
+     <path d="M 466.440562 441.498353 
+L 576.029438 441.498353 
+L 576.029438 417.498353 
+L 466.440562 417.498353 
 z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #8ecf67; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_232">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="451.733665" transform="rotate(-0 920.263575 451.733665)">14886.02</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="432.533665" transform="rotate(-0 477.39945 432.533665)">8.18</text>
     </g>
     <g id="patch_232">
-     <path d="M 1002.669937 460.698353 
-L 1119.195 460.698353 
-L 1119.195 436.698353 
-L 1002.669937 436.698353 
+     <path d="M 576.029438 441.498353 
+L 639.014063 441.498353 
+L 639.014063 417.498353 
+L 576.029438 417.498353 
 z
-" style="fill: #016a38; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_233">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="451.733665" transform="rotate(-0 1014.322444 451.733665)">90.07</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="432.533665" transform="rotate(-0 582.3279 432.533665)">---</text>
     </g>
     <g id="patch_233">
-     <path d="M 1119.195 460.698353 
-L 1211.766187 460.698353 
-L 1211.766187 436.698353 
-L 1119.195 436.698353 
+     <path d="M 639.014063 441.498353 
+L 744.40575 441.498353 
+L 744.40575 417.498353 
+L 639.014063 417.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_234">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="451.733665" transform="rotate(-0 1128.452119 451.733665)">44.61</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="432.533665" transform="rotate(-0 649.553231 432.533665)">---</text>
     </g>
     <g id="patch_234">
-     <path d="M 1211.766187 460.698353 
-L 1351.182937 460.698353 
-L 1351.182937 436.698353 
-L 1211.766187 436.698353 
+     <path d="M 744.40575 441.498353 
+L 881.238187 441.498353 
+L 881.238187 417.498353 
+L 744.40575 417.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_235">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="451.733665" transform="rotate(-0 1225.707862 451.733665)">5.58</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="432.533665" transform="rotate(-0 758.088994 432.533665)">---</text>
     </g>
     <g id="patch_235">
-     <path d="M 1351.182937 460.698353 
-L 1435.57425 460.698353 
-L 1435.57425 436.698353 
-L 1351.182937 436.698353 
+     <path d="M 881.238187 441.498353 
+L 982.407937 441.498353 
+L 982.407937 417.498353 
+L 881.238187 417.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_236">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="451.733665" transform="rotate(-0 1359.622069 451.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="432.533665" transform="rotate(-0 891.355163 432.533665)">---</text>
     </g>
     <g id="patch_236">
-     <path d="M 0 484.698353 
-L 128.297812 484.698353 
-L 128.297812 460.698353 
-L 0 460.698353 
+     <path d="M 982.407937 441.498353 
+L 1071.918375 441.498353 
+L 1071.918375 417.498353 
+L 982.407937 417.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #6bbf64; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_237">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="475.733665" transform="rotate(-0 12.829781 475.733665)">MP-PalmDet</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="432.533665" transform="rotate(-0 991.358981 432.533665)">5.62</text>
     </g>
     <g id="patch_237">
-     <path d="M 128.297812 484.698353 
-L 335.566687 484.698353 
-L 335.566687 460.698353 
-L 128.297812 460.698353 
+     <path d="M 1071.918375 441.498353 
+L 1168.705313 441.498353 
+L 1168.705313 417.498353 
+L 1071.918375 417.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #66bd63; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_238">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="475.733665" transform="rotate(-0 149.0247 475.733665)">Palm Detection</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="432.533665" transform="rotate(-0 1081.597069 432.533665)">5.29</text>
     </g>
     <g id="patch_238">
-     <path d="M 335.566687 484.698353 
-L 402.168937 484.698353 
-L 402.168937 460.698353 
-L 335.566687 460.698353 
+     <path d="M 1168.705313 441.498353 
+L 1264.448625 441.498353 
+L 1264.448625 417.498353 
+L 1168.705313 417.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_239">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="475.733665" transform="rotate(-0 342.226912 475.733665)">192x192</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="432.533665" transform="rotate(-0 1178.279644 432.533665)">---</text>
     </g>
     <g id="patch_239">
-     <path d="M 402.168937 484.698353 
-L 505.524937 484.698353 
-L 505.524937 460.698353 
-L 402.168937 460.698353 
+     <path d="M 1264.448625 441.498353 
+L 1353.959063 441.498353 
+L 1353.959063 417.498353 
+L 1264.448625 417.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_240">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="475.733665" transform="rotate(-0 412.504537 475.733665)">6.29</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="432.533665" transform="rotate(-0 1273.399669 432.533665)">---</text>
     </g>
     <g id="patch_240">
-     <path d="M 505.524937 484.698353 
-L 592.378875 484.698353 
-L 592.378875 460.698353 
-L 505.524937 460.698353 
+     <path d="M 1353.959063 441.498353 
+L 1450.746 441.498353 
+L 1450.746 417.498353 
+L 1353.959063 417.498353 
 z
-" style="fill: #118848; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_241">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="475.733665" transform="rotate(-0 514.210331 475.733665)">86.83</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="432.533665" transform="rotate(-0 1363.637756 432.533665)">---</text>
     </g>
     <g id="patch_241">
-     <path d="M 592.378875 484.698353 
-L 709.27725 484.698353 
-L 709.27725 460.698353 
-L 592.378875 460.698353 
+     <path d="M 1450.746 441.498353 
+L 1546.489312 441.498353 
+L 1546.489312 417.498353 
+L 1450.746 417.498353 
 z
-" style="fill: #fa9857; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_242">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="475.733665" transform="rotate(-0 604.068712 475.733665)">872.09</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="432.533665" transform="rotate(-0 1460.320331 432.533665)">---</text>
     </g>
     <g id="patch_242">
-     <path d="M 709.27725 484.698353 
-L 809.53125 484.698353 
-L 809.53125 460.698353 
-L 709.27725 460.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/object_tracking_dasiamrpn">
+      <path d="M 0 465.498353 
+L 128.297812 465.498353 
+L 128.297812 441.498353 
+L 0 441.498353 
 z
-" style="fill: #07753e; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_243">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="475.733665" transform="rotate(-0 719.30265 475.733665)">38.03</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/object_tracking_dasiamrpn">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="456.533665" transform="rotate(-0 12.829781 456.533665)">DaSiamRPN</text>
+     </a>
     </g>
     <g id="patch_243">
-     <path d="M 809.53125 484.698353 
-L 911.107312 484.698353 
-L 911.107312 460.698353 
-L 809.53125 460.698353 
+     <path d="M 128.297812 465.498353 
+L 335.566688 465.498353 
+L 335.566688 441.498353 
+L 128.297812 441.498353 
 z
-" style="fill: #249d53; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_244">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="475.733665" transform="rotate(-0 819.688856 475.733665)">142.23</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="456.533665" transform="rotate(-0 149.0247 456.533665)">Object Tracking</text>
     </g>
     <g id="patch_244">
-     <path d="M 911.107312 484.698353 
-L 1002.669937 484.698353 
-L 1002.669937 460.698353 
-L 911.107312 460.698353 
+     <path d="M 335.566688 465.498353 
+L 410.291063 465.498353 
+L 410.291063 441.498353 
+L 335.566688 441.498353 
 z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_245">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="475.733665" transform="rotate(-0 920.263575 475.733665)">1191.81</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="456.533665" transform="rotate(-0 343.039125 456.533665)">1280x720</text>
     </g>
     <g id="patch_245">
-     <path d="M 1002.669937 484.698353 
-L 1119.195 484.698353 
-L 1119.195 460.698353 
-L 1002.669937 460.698353 
+     <path d="M 410.291063 465.498353 
+L 466.440562 465.498353 
+L 466.440562 441.498353 
+L 410.291063 441.498353 
 z
-" style="fill: #108647; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_246">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="475.733665" transform="rotate(-0 1014.322444 475.733665)">83.20</text>
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="456.533665" transform="rotate(-0 415.906013 456.533665)">29.46</text>
     </g>
     <g id="patch_246">
-     <path d="M 1119.195 484.698353 
-L 1211.766187 484.698353 
-L 1211.766187 460.698353 
-L 1119.195 460.698353 
+     <path d="M 466.440562 465.498353 
+L 576.029438 465.498353 
+L 576.029438 441.498353 
+L 466.440562 441.498353 
 z
-" style="fill: #06733d; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #feffbe; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_247">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="475.733665" transform="rotate(-0 1128.452119 475.733665)">33.81</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="456.533665" transform="rotate(-0 477.39945 456.533665)">762.56</text>
     </g>
     <g id="patch_247">
-     <path d="M 1211.766187 484.698353 
-L 1351.182937 484.698353 
-L 1351.182937 460.698353 
-L 1211.766187 460.698353 
+     <path d="M 576.029438 465.498353 
+L 639.014063 465.498353 
+L 639.014063 441.498353 
+L 576.029438 441.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_248">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="475.733665" transform="rotate(-0 1225.707862 475.733665)">5.17</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="456.533665" transform="rotate(-0 582.3279 456.533665)">14738.64</text>
     </g>
     <g id="patch_248">
-     <path d="M 1351.182937 484.698353 
-L 1435.57425 484.698353 
-L 1435.57425 460.698353 
-L 1351.182937 460.698353 
+     <path d="M 639.014063 465.498353 
+L 744.40575 465.498353 
+L 744.40575 441.498353 
+L 639.014063 441.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #69be63; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_249">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="475.733665" transform="rotate(-0 1359.622069 475.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="456.533665" transform="rotate(-0 649.553231 456.533665)">152.78</text>
     </g>
     <g id="patch_249">
-     <path d="M 0 508.698353 
-L 128.297812 508.698353 
-L 128.297812 484.698353 
-L 0 484.698353 
+     <path d="M 744.40575 465.498353 
+L 881.238187 465.498353 
+L 881.238187 441.498353 
+L 744.40575 441.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #fff0a6; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_250">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="499.733665" transform="rotate(-0 12.829781 499.733665)">MP-HandPose</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="456.533665" transform="rotate(-0 758.088994 456.533665)">929.63</text>
     </g>
     <g id="patch_250">
-     <path d="M 128.297812 508.698353 
-L 335.566687 508.698353 
-L 335.566687 484.698353 
-L 128.297812 484.698353 
+     <path d="M 881.238187 465.498353 
+L 982.407937 465.498353 
+L 982.407937 441.498353 
+L 881.238187 441.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_251">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="499.733665" transform="rotate(-0 149.0247 499.733665)">Hand Pose Estimation</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="456.533665" transform="rotate(-0 891.355163 456.533665)">19800.14</text>
     </g>
     <g id="patch_251">
-     <path d="M 335.566687 508.698353 
-L 402.168937 508.698353 
-L 402.168937 484.698353 
-L 335.566687 484.698353 
+     <path d="M 982.407937 465.498353 
+L 1071.918375 465.498353 
+L 1071.918375 441.498353 
+L 982.407937 441.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #d1ec86; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_252">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="499.733665" transform="rotate(-0 342.226912 499.733665)">224x224</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="456.533665" transform="rotate(-0 991.358981 456.533665)">466.19</text>
     </g>
     <g id="patch_252">
-     <path d="M 402.168937 508.698353 
-L 505.524937 508.698353 
-L 505.524937 484.698353 
-L 402.168937 484.698353 
+     <path d="M 1071.918375 465.498353 
+L 1168.705313 465.498353 
+L 1168.705313 441.498353 
+L 1071.918375 441.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #c7e77f; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_253">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="499.733665" transform="rotate(-0 412.504537 499.733665)">4.68</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="456.533665" transform="rotate(-0 1081.597069 456.533665)">428.66</text>
     </g>
     <g id="patch_253">
-     <path d="M 505.524937 508.698353 
-L 592.378875 508.698353 
-L 592.378875 484.698353 
-L 505.524937 484.698353 
+     <path d="M 1168.705313 465.498353 
+L 1264.448625 465.498353 
+L 1264.448625 441.498353 
+L 1168.705313 441.498353 
 z
-" style="fill: #0f8446; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #f5fbb2; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_254">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="499.733665" transform="rotate(-0 514.210331 499.733665)">43.57</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="456.533665" transform="rotate(-0 1178.279644 456.533665)">701.08</text>
     </g>
     <g id="patch_254">
-     <path d="M 592.378875 508.698353 
-L 709.27725 508.698353 
-L 709.27725 484.698353 
-L 592.378875 484.698353 
+     <path d="M 1264.448625 465.498353 
+L 1353.959063 465.498353 
+L 1353.959063 441.498353 
+L 1264.448625 441.498353 
 z
-" style="fill: #fba05b; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #2da155; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_255">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="499.733665" transform="rotate(-0 604.068712 499.733665)">460.56</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="456.533665" transform="rotate(-0 1273.399669 456.533665)">76.54</text>
     </g>
     <g id="patch_255">
-     <path d="M 709.27725 508.698353 
-L 809.53125 508.698353 
-L 809.53125 484.698353 
-L 709.27725 484.698353 
+     <path d="M 1353.959063 465.498353 
+L 1450.746 465.498353 
+L 1450.746 441.498353 
+L 1353.959063 441.498353 
 z
-" style="fill: #06733d; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_256">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="499.733665" transform="rotate(-0 719.30265 499.733665)">20.27</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="456.533665" transform="rotate(-0 1363.637756 456.533665)">---</text>
     </g>
     <g id="patch_256">
-     <path d="M 809.53125 508.698353 
-L 911.107312 508.698353 
-L 911.107312 484.698353 
-L 809.53125 484.698353 
+     <path d="M 1450.746 465.498353 
+L 1546.489312 465.498353 
+L 1546.489312 441.498353 
+L 1450.746 441.498353 
 z
-" style="fill: #279f53; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_257">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="499.733665" transform="rotate(-0 819.688856 499.733665)">80.67</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="456.533665" transform="rotate(-0 1460.320331 456.533665)">---</text>
     </g>
     <g id="patch_257">
-     <path d="M 911.107312 508.698353 
-L 1002.669937 508.698353 
-L 1002.669937 484.698353 
-L 911.107312 484.698353 
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/person_reid_youtureid">
+      <path d="M 0 489.498353 
+L 128.297812 489.498353 
+L 128.297812 465.498353 
+L 0 465.498353 
 z
-" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
     </g>
     <g id="text_258">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="499.733665" transform="rotate(-0 920.263575 499.733665)">636.22</text>
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/person_reid_youtureid">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="480.533665" transform="rotate(-0 12.829781 480.533665)">YoutuReID</text>
+     </a>
     </g>
     <g id="patch_258">
-     <path d="M 1002.669937 508.698353 
-L 1119.195 508.698353 
-L 1119.195 484.698353 
-L 1002.669937 484.698353 
+     <path d="M 128.297812 489.498353 
+L 335.566688 489.498353 
+L 335.566688 465.498353 
+L 128.297812 465.498353 
 z
-" style="fill: #0e8245; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_259">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="499.733665" transform="rotate(-0 1014.322444 499.733665)">40.10</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="480.533665" transform="rotate(-0 149.0247 480.533665)">Person Re-Identification</text>
     </g>
     <g id="patch_259">
-     <path d="M 1119.195 508.698353 
-L 1211.766187 508.698353 
-L 1211.766187 484.698353 
-L 1119.195 484.698353 
+     <path d="M 335.566688 489.498353 
+L 410.291063 489.498353 
+L 410.291063 465.498353 
+L 335.566688 465.498353 
 z
-" style="fill: #05713c; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_260">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="499.733665" transform="rotate(-0 1128.452119 499.733665)">19.47</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="480.533665" transform="rotate(-0 343.039125 480.533665)">128x256</text>
     </g>
     <g id="patch_260">
-     <path d="M 1211.766187 508.698353 
-L 1351.182937 508.698353 
-L 1351.182937 484.698353 
-L 1211.766187 484.698353 
+     <path d="M 410.291063 489.498353 
+L 466.440562 489.498353 
+L 466.440562 465.498353 
+L 410.291063 465.498353 
 z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #54b45f; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_261">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="499.733665" transform="rotate(-0 1225.707862 499.733665)">6.27</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="480.533665" transform="rotate(-0 415.906013 480.533665)">30.87</text>
     </g>
     <g id="patch_261">
-     <path d="M 1351.182937 508.698353 
-L 1435.57425 508.698353 
-L 1435.57425 484.698353 
-L 1351.182937 484.698353 
+     <path d="M 466.440562 489.498353 
+L 576.029438 489.498353 
+L 576.029438 465.498353 
+L 466.440562 465.498353 
 z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+" style="fill: #cc2627; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_262">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="499.733665" transform="rotate(-0 1359.622069 499.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="480.533665" transform="rotate(-0 477.39945 480.533665)">676.15</text>
     </g>
     <g id="patch_262">
-     <path d="M 0 532.698353 
-L 128.297812 532.698353 
-L 128.297812 508.698353 
-L 0 508.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_263">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="523.733665" transform="rotate(-0 12.829781 523.733665)">MP-PersonDet</text>
-    </g>
-    <g id="patch_263">
-     <path d="M 128.297812 532.698353 
-L 335.566687 532.698353 
-L 335.566687 508.698353 
-L 128.297812 508.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_264">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="523.733665" transform="rotate(-0 149.0247 523.733665)">Person Detection</text>
-    </g>
-    <g id="patch_264">
-     <path d="M 335.566687 532.698353 
-L 402.168937 532.698353 
-L 402.168937 508.698353 
-L 335.566687 508.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_265">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="342.226912" y="523.733665" transform="rotate(-0 342.226912 523.733665)">224x224</text>
-    </g>
-    <g id="patch_265">
-     <path d="M 402.168937 532.698353 
-L 505.524937 532.698353 
-L 505.524937 508.698353 
-L 402.168937 508.698353 
-z
-" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_266">
-     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="412.504537" y="523.733665" transform="rotate(-0 412.504537 523.733665)">13.88</text>
-    </g>
-    <g id="patch_266">
-     <path d="M 505.524937 532.698353 
-L 592.378875 532.698353 
-L 592.378875 508.698353 
-L 505.524937 508.698353 
-z
-" style="fill: #0b7d42; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_267">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="514.210331" y="523.733665" transform="rotate(-0 514.210331 523.733665)">98.52</text>
-    </g>
-    <g id="patch_267">
-     <path d="M 592.378875 532.698353 
-L 709.27725 532.698353 
-L 709.27725 508.698353 
-L 592.378875 508.698353 
-z
-" style="fill: #fba05b; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_268">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="604.068712" y="523.733665" transform="rotate(-0 604.068712 523.733665)">1326.56</text>
-    </g>
-    <g id="patch_268">
-     <path d="M 709.27725 532.698353 
-L 809.53125 532.698353 
-L 809.53125 508.698353 
-L 709.27725 508.698353 
-z
-" style="fill: #04703b; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_269">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="719.30265" y="523.733665" transform="rotate(-0 719.30265 523.733665)">46.07</text>
-    </g>
-    <g id="patch_269">
-     <path d="M 809.53125 532.698353 
-L 911.107312 532.698353 
-L 911.107312 508.698353 
-L 809.53125 508.698353 
-z
-" style="fill: #18954f; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_270">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="819.688856" y="523.733665" transform="rotate(-0 819.688856 523.733665)">191.41</text>
-    </g>
-    <g id="patch_270">
-     <path d="M 911.107312 532.698353 
-L 1002.669937 532.698353 
-L 1002.669937 508.698353 
-L 911.107312 508.698353 
+     <path d="M 576.029438 489.498353 
+L 639.014063 489.498353 
+L 639.014063 465.498353 
+L 576.029438 465.498353 
 z
 " style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_263">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="480.533665" transform="rotate(-0 582.3279 480.533665)">11117.07</text>
+    </g>
+    <g id="patch_263">
+     <path d="M 639.014063 489.498353 
+L 744.40575 489.498353 
+L 744.40575 465.498353 
+L 639.014063 465.498353 
+z
+" style="fill: #fbfdba; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_264">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="480.533665" transform="rotate(-0 649.553231 480.533665)">195.67</text>
+    </g>
+    <g id="patch_264">
+     <path d="M 744.40575 489.498353 
+L 881.238187 489.498353 
+L 881.238187 465.498353 
+L 744.40575 465.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_265">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="480.533665" transform="rotate(-0 758.088994 480.533665)">898.23</text>
+    </g>
+    <g id="patch_265">
+     <path d="M 881.238187 489.498353 
+L 982.407937 489.498353 
+L 982.407937 465.498353 
+L 881.238187 465.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_266">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="480.533665" transform="rotate(-0 891.355163 480.533665)">14886.02</text>
+    </g>
+    <g id="patch_266">
+     <path d="M 982.407937 489.498353 
+L 1071.918375 489.498353 
+L 1071.918375 465.498353 
+L 982.407937 465.498353 
+z
+" style="fill: #fca55d; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_267">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="480.533665" transform="rotate(-0 991.358981 480.533665)">411.49</text>
+    </g>
+    <g id="patch_267">
+     <path d="M 1071.918375 489.498353 
+L 1168.705313 489.498353 
+L 1168.705313 465.498353 
+L 1071.918375 465.498353 
+z
+" style="fill: #f99355; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_268">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="480.533665" transform="rotate(-0 1081.597069 480.533665)">439.53</text>
+    </g>
+    <g id="patch_268">
+     <path d="M 1168.705313 489.498353 
+L 1264.448625 489.498353 
+L 1264.448625 465.498353 
+L 1168.705313 465.498353 
+z
+" style="fill: #da362a; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_269">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="480.533665" transform="rotate(-0 1178.279644 480.533665)">631.70</text>
+    </g>
+    <g id="patch_269">
+     <path d="M 1264.448625 489.498353 
+L 1353.959063 489.498353 
+L 1353.959063 465.498353 
+L 1264.448625 465.498353 
+z
+" style="fill: #d3ec87; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_270">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="480.533665" transform="rotate(-0 1273.399669 480.533665)">126.65</text>
+    </g>
+    <g id="patch_270">
+     <path d="M 1353.959063 489.498353 
+L 1450.746 489.498353 
+L 1450.746 465.498353 
+L 1353.959063 465.498353 
+z
+" style="fill: #fed884; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
     <g id="text_271">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="920.263575" y="523.733665" transform="rotate(-0 920.263575 523.733665)">1835.97</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="480.533665" transform="rotate(-0 1363.637756 480.533665)">307.90</text>
     </g>
     <g id="patch_271">
-     <path d="M 1002.669937 532.698353 
-L 1119.195 532.698353 
-L 1119.195 508.698353 
-L 1002.669937 508.698353 
-z
-" style="fill: #06733d; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_272">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1014.322444" y="523.733665" transform="rotate(-0 1014.322444 523.733665)">56.69</text>
-    </g>
-    <g id="patch_272">
-     <path d="M 1119.195 532.698353 
-L 1211.766187 532.698353 
-L 1211.766187 508.698353 
-L 1119.195 508.698353 
-z
-" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
-    </g>
-    <g id="text_273">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1128.452119" y="523.733665" transform="rotate(-0 1128.452119 523.733665)">---</text>
-    </g>
-    <g id="patch_273">
-     <path d="M 1211.766187 532.698353 
-L 1351.182937 532.698353 
-L 1351.182937 508.698353 
-L 1211.766187 508.698353 
+     <path d="M 1450.746 489.498353 
+L 1546.489312 489.498353 
+L 1546.489312 465.498353 
+L 1450.746 465.498353 
 z
 " style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
     </g>
+    <g id="text_272">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="480.533665" transform="rotate(-0 1460.320331 480.533665)">5.58</text>
+    </g>
+    <g id="patch_272">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/palm_detection_mediapipe">
+      <path d="M 0 513.498353 
+L 128.297812 513.498353 
+L 128.297812 489.498353 
+L 0 489.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
+    <g id="text_273">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/palm_detection_mediapipe">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="504.533665" transform="rotate(-0 12.829781 504.533665)">MP-PalmDet</text>
+     </a>
+    </g>
+    <g id="patch_273">
+     <path d="M 128.297812 513.498353 
+L 335.566688 513.498353 
+L 335.566688 489.498353 
+L 128.297812 489.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
     <g id="text_274">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1225.707862" y="523.733665" transform="rotate(-0 1225.707862 523.733665)">16.45</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="504.533665" transform="rotate(-0 149.0247 504.533665)">Palm Detection</text>
     </g>
     <g id="patch_274">
-     <path d="M 1351.182937 532.698353 
-L 1435.57425 532.698353 
-L 1435.57425 508.698353 
-L 1351.182937 508.698353 
+     <path d="M 335.566688 513.498353 
+L 410.291063 513.498353 
+L 410.291063 489.498353 
+L 335.566688 489.498353 
 z
 " style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
     </g>
     <g id="text_275">
-     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1359.622069" y="523.733665" transform="rotate(-0 1359.622069 523.733665)">---</text>
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="504.533665" transform="rotate(-0 343.039125 504.533665)">192x192</text>
+    </g>
+    <g id="patch_275">
+     <path d="M 410.291063 513.498353 
+L 466.440562 513.498353 
+L 466.440562 489.498353 
+L 410.291063 489.498353 
+z
+" style="fill: #0b7d42; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_276">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="504.533665" transform="rotate(-0 415.906013 504.533665)">6.14</text>
+    </g>
+    <g id="patch_276">
+     <path d="M 466.440562 513.498353 
+L 576.029438 513.498353 
+L 576.029438 489.498353 
+L 466.440562 489.498353 
+z
+" style="fill: #dff293; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_277">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="504.533665" transform="rotate(-0 477.39945 504.533665)">91.48</text>
+    </g>
+    <g id="patch_277">
+     <path d="M 576.029438 513.498353 
+L 639.014063 513.498353 
+L 639.014063 489.498353 
+L 576.029438 489.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_278">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="504.533665" transform="rotate(-0 582.3279 504.533665)">872.09</text>
+    </g>
+    <g id="patch_278">
+     <path d="M 639.014063 513.498353 
+L 744.40575 513.498353 
+L 744.40575 489.498353 
+L 639.014063 489.498353 
+z
+" style="fill: #89cc67; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_279">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="504.533665" transform="rotate(-0 649.553231 504.533665)">38.03</text>
+    </g>
+    <g id="patch_279">
+     <path d="M 744.40575 513.498353 
+L 881.238187 513.498353 
+L 881.238187 489.498353 
+L 744.40575 489.498353 
+z
+" style="fill: #fff7b2; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_280">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="504.533665" transform="rotate(-0 758.088994 504.533665)">142.23</text>
+    </g>
+    <g id="patch_280">
+     <path d="M 881.238187 513.498353 
+L 982.407937 513.498353 
+L 982.407937 489.498353 
+L 881.238187 489.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_281">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="504.533665" transform="rotate(-0 891.355163 504.533665)">1191.81</text>
+    </g>
+    <g id="patch_281">
+     <path d="M 982.407937 513.498353 
+L 1071.918375 513.498353 
+L 1071.918375 489.498353 
+L 982.407937 489.498353 
+z
+" style="fill: #c5e67e; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_282">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="504.533665" transform="rotate(-0 991.358981 504.533665)">69.60</text>
+    </g>
+    <g id="patch_282">
+     <path d="M 1071.918375 513.498353 
+L 1168.705313 513.498353 
+L 1168.705313 489.498353 
+L 1071.918375 489.498353 
+z
+" style="fill: #c1e57b; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_283">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="504.533665" transform="rotate(-0 1081.597069 504.533665)">66.91</text>
+    </g>
+    <g id="patch_283">
+     <path d="M 1168.705313 513.498353 
+L 1264.448625 513.498353 
+L 1264.448625 489.498353 
+L 1168.705313 489.498353 
+z
+" style="fill: #ecf7a6; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_284">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="504.533665" transform="rotate(-0 1178.279644 504.533665)">105.23</text>
+    </g>
+    <g id="patch_284">
+     <path d="M 1264.448625 513.498353 
+L 1353.959063 513.498353 
+L 1353.959063 489.498353 
+L 1264.448625 489.498353 
+z
+" style="fill: #c1e57b; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_285">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="504.533665" transform="rotate(-0 1273.399669 504.533665)">67.34</text>
+    </g>
+    <g id="patch_285">
+     <path d="M 1353.959063 513.498353 
+L 1450.746 513.498353 
+L 1450.746 489.498353 
+L 1353.959063 489.498353 
+z
+" style="fill: #e3f399; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_286">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="504.533665" transform="rotate(-0 1363.637756 504.533665)">95.92</text>
+    </g>
+    <g id="patch_286">
+     <path d="M 1450.746 513.498353 
+L 1546.489312 513.498353 
+L 1546.489312 489.498353 
+L 1450.746 489.498353 
+z
+" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_287">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="504.533665" transform="rotate(-0 1460.320331 504.533665)">5.17</text>
+    </g>
+    <g id="patch_287">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/handpose_estimation_mediapipe">
+      <path d="M 0 537.498353 
+L 128.297812 537.498353 
+L 128.297812 513.498353 
+L 0 513.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
+    <g id="text_288">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/handpose_estimation_mediapipe">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="528.533665" transform="rotate(-0 12.829781 528.533665)">MP-HandPose</text>
+     </a>
+    </g>
+    <g id="patch_288">
+     <path d="M 128.297812 537.498353 
+L 335.566688 537.498353 
+L 335.566688 513.498353 
+L 128.297812 513.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_289">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="528.533665" transform="rotate(-0 149.0247 528.533665)">Hand Pose Estimation</text>
+    </g>
+    <g id="patch_289">
+     <path d="M 335.566688 537.498353 
+L 410.291063 537.498353 
+L 410.291063 513.498353 
+L 335.566688 513.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_290">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="528.533665" transform="rotate(-0 343.039125 528.533665)">224x224</text>
+    </g>
+    <g id="patch_290">
+     <path d="M 410.291063 537.498353 
+L 466.440562 537.498353 
+L 466.440562 513.498353 
+L 410.291063 513.498353 
+z
+" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_291">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="528.533665" transform="rotate(-0 415.906013 528.533665)">4.68</text>
+    </g>
+    <g id="patch_291">
+     <path d="M 466.440562 537.498353 
+L 576.029438 537.498353 
+L 576.029438 513.498353 
+L 466.440562 513.498353 
+z
+" style="fill: #98d368; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_292">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="528.533665" transform="rotate(-0 477.39945 528.533665)">43.85</text>
+    </g>
+    <g id="patch_292">
+     <path d="M 576.029438 537.498353 
+L 639.014063 537.498353 
+L 639.014063 513.498353 
+L 576.029438 513.498353 
+z
+" style="fill: #b91326; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_293">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="528.533665" transform="rotate(-0 582.3279 528.533665)">460.56</text>
+    </g>
+    <g id="patch_293">
+     <path d="M 639.014063 537.498353 
+L 744.40575 537.498353 
+L 744.40575 513.498353 
+L 639.014063 513.498353 
+z
+" style="fill: #54b45f; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_294">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="528.533665" transform="rotate(-0 649.553231 528.533665)">20.27</text>
+    </g>
+    <g id="patch_294">
+     <path d="M 744.40575 537.498353 
+L 881.238187 537.498353 
+L 881.238187 513.498353 
+L 744.40575 513.498353 
+z
+" style="fill: #d5ed88; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_295">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="528.533665" transform="rotate(-0 758.088994 528.533665)">80.67</text>
+    </g>
+    <g id="patch_295">
+     <path d="M 881.238187 537.498353 
+L 982.407937 537.498353 
+L 982.407937 513.498353 
+L 881.238187 513.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_296">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="528.533665" transform="rotate(-0 891.355163 528.533665)">636.22</text>
+    </g>
+    <g id="patch_296">
+     <path d="M 982.407937 537.498353 
+L 1071.918375 537.498353 
+L 1071.918375 513.498353 
+L 982.407937 513.498353 
+z
+" style="fill: #93d168; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_297">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="528.533665" transform="rotate(-0 991.358981 528.533665)">41.02</text>
+    </g>
+    <g id="patch_297">
+     <path d="M 1071.918375 537.498353 
+L 1168.705313 537.498353 
+L 1168.705313 513.498353 
+L 1071.918375 513.498353 
+z
+" style="fill: #8ccd67; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_298">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="528.533665" transform="rotate(-0 1081.597069 528.533665)">38.60</text>
+    </g>
+    <g id="patch_298">
+     <path d="M 1168.705313 537.498353 
+L 1264.448625 537.498353 
+L 1264.448625 513.498353 
+L 1168.705313 513.498353 
+z
+" style="fill: #b3df72; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_299">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="528.533665" transform="rotate(-0 1178.279644 528.533665)">57.95</text>
+    </g>
+    <g id="patch_299">
+     <path d="M 1264.448625 537.498353 
+L 1353.959063 537.498353 
+L 1353.959063 513.498353 
+L 1264.448625 513.498353 
+z
+" style="fill: #93d168; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_300">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="528.533665" transform="rotate(-0 1273.399669 528.533665)">41.15</text>
+    </g>
+    <g id="patch_300">
+     <path d="M 1353.959063 537.498353 
+L 1450.746 537.498353 
+L 1450.746 513.498353 
+L 1353.959063 513.498353 
+z
+" style="fill: #9bd469; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_301">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="528.533665" transform="rotate(-0 1363.637756 528.533665)">44.36</text>
+    </g>
+    <g id="patch_301">
+     <path d="M 1450.746 537.498353 
+L 1546.489312 537.498353 
+L 1546.489312 513.498353 
+L 1450.746 513.498353 
+z
+" style="fill: #0e8245; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_302">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="528.533665" transform="rotate(-0 1460.320331 528.533665)">6.27</text>
+    </g>
+    <g id="patch_302">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/person_detection_mediapipe">
+      <path d="M 0 561.498353 
+L 128.297812 561.498353 
+L 128.297812 537.498353 
+L 0 537.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+     </a>
+    </g>
+    <g id="text_303">
+     <a xlink:href="https://github.com/opencv/opencv_zoo/tree/master/models/person_detection_mediapipe">
+      <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="12.829781" y="552.533665" transform="rotate(-0 12.829781 552.533665)">MP-PersonDet</text>
+     </a>
+    </g>
+    <g id="patch_303">
+     <path d="M 128.297812 561.498353 
+L 335.566688 561.498353 
+L 335.566688 537.498353 
+L 128.297812 537.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_304">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="149.0247" y="552.533665" transform="rotate(-0 149.0247 552.533665)">Person Detection</text>
+    </g>
+    <g id="patch_304">
+     <path d="M 335.566688 561.498353 
+L 410.291063 561.498353 
+L 410.291063 537.498353 
+L 335.566688 537.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_305">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.039125" y="552.533665" transform="rotate(-0 343.039125 552.533665)">224x224</text>
+    </g>
+    <g id="patch_305">
+     <path d="M 410.291063 561.498353 
+L 466.440562 561.498353 
+L 466.440562 537.498353 
+L 410.291063 537.498353 
+z
+" style="fill: #006837; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_306">
+     <text style="fill: #ffffff; font: 700 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="415.906013" y="552.533665" transform="rotate(-0 415.906013 552.533665)">13.88</text>
+    </g>
+    <g id="patch_306">
+     <path d="M 466.440562 561.498353 
+L 576.029438 561.498353 
+L 576.029438 537.498353 
+L 466.440562 537.498353 
+z
+" style="fill: #89cc67; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_307">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="477.39945" y="552.533665" transform="rotate(-0 477.39945 552.533665)">98.52</text>
+    </g>
+    <g id="patch_307">
+     <path d="M 576.029438 561.498353 
+L 639.014063 561.498353 
+L 639.014063 537.498353 
+L 576.029438 537.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_308">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="582.3279" y="552.533665" transform="rotate(-0 582.3279 552.533665)">1326.56</text>
+    </g>
+    <g id="patch_308">
+     <path d="M 639.014063 561.498353 
+L 744.40575 561.498353 
+L 744.40575 537.498353 
+L 639.014063 537.498353 
+z
+" style="fill: #45ad5b; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_309">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="649.553231" y="552.533665" transform="rotate(-0 649.553231 552.533665)">46.07</text>
+    </g>
+    <g id="patch_309">
+     <path d="M 744.40575 561.498353 
+L 881.238187 561.498353 
+L 881.238187 537.498353 
+L 744.40575 537.498353 
+z
+" style="fill: #cbe982; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_310">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="758.088994" y="552.533665" transform="rotate(-0 758.088994 552.533665)">191.41</text>
+    </g>
+    <g id="patch_310">
+     <path d="M 881.238187 561.498353 
+L 982.407937 561.498353 
+L 982.407937 537.498353 
+L 881.238187 537.498353 
+z
+" style="fill: #a50026; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_311">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="891.355163" y="552.533665" transform="rotate(-0 891.355163 552.533665)">1835.97</text>
+    </g>
+    <g id="patch_311">
+     <path d="M 982.407937 561.498353 
+L 1071.918375 561.498353 
+L 1071.918375 537.498353 
+L 982.407937 537.498353 
+z
+" style="fill: #89cc67; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_312">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="991.358981" y="552.533665" transform="rotate(-0 991.358981 552.533665)">98.38</text>
+    </g>
+    <g id="patch_312">
+     <path d="M 1071.918375 561.498353 
+L 1168.705313 561.498353 
+L 1168.705313 537.498353 
+L 1071.918375 537.498353 
+z
+" style="fill: #7ac665; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_313">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1081.597069" y="552.533665" transform="rotate(-0 1081.597069 552.533665)">84.42</text>
+    </g>
+    <g id="patch_313">
+     <path d="M 1168.705313 561.498353 
+L 1264.448625 561.498353 
+L 1264.448625 537.498353 
+L 1168.705313 537.498353 
+z
+" style="fill: #a9da6c; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_314">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1178.279644" y="552.533665" transform="rotate(-0 1178.279644 552.533665)">134.10</text>
+    </g>
+    <g id="patch_314">
+     <path d="M 1264.448625 561.498353 
+L 1353.959063 561.498353 
+L 1353.959063 537.498353 
+L 1264.448625 537.498353 
+z
+" style="fill: #57b65f; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_315">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1273.399669" y="552.533665" transform="rotate(-0 1273.399669 552.533665)">56.69</text>
+    </g>
+    <g id="patch_315">
+     <path d="M 1353.959063 561.498353 
+L 1450.746 561.498353 
+L 1450.746 537.498353 
+L 1353.959063 537.498353 
+z
+" style="fill: #ffffff; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_316">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1363.637756" y="552.533665" transform="rotate(-0 1363.637756 552.533665)">---</text>
+    </g>
+    <g id="patch_316">
+     <path d="M 1450.746 561.498353 
+L 1546.489312 561.498353 
+L 1546.489312 537.498353 
+L 1450.746 537.498353 
+z
+" style="fill: #0b7d42; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_317">
+     <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="1460.320331" y="552.533665" transform="rotate(-0 1460.320331 552.533665)">16.45</text>
     </g>
    </g>
   </g>
   <g id="axes_3">
-   <g id="text_276">
-    <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="0" y="553.891167" transform="rotate(-0 0 553.891167)">\*: Models are quantized in per-channel mode, which run slower than per-tensor quantized models on NPU.</text>
+   <g id="text_318">
+    <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="0" y="585.300108" transform="rotate(-0 0 585.300108)">Units: All data in milliseconds (ms).</text>
+   </g>
+   <g id="text_319">
+    <text style="font: 11px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="0" y="598.344814" transform="rotate(-0 0 598.344814)">\*: Models are quantized in per-channel mode, which run slower than per-tensor quantized models on NPU.</text>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pba7c3a785f">
-   <rect x="378" y="0" width="558" height="13.044706"/>
+  <clipPath id="pdeedcc1849">
+   <rect x="544.784516" y="0" width="558" height="13.044706"/>
   </clipPath>
  </defs>
 </svg>

--- a/benchmark/generate_table.py
+++ b/benchmark/generate_table.py
@@ -2,94 +2,193 @@ import re
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import numpy as np
+import yaml
 
-mpl.use("svg")
 
 # parse a '.md' file and find a table. return table information
-def parse_table(filepath):
+def parse_table(filepath, cfg):
+    #  parse benchmark data
+    def _parse_benchmark_data(lines):
+        raw_data = []
+        for l in lines:
+            l = l.strip()
+            # parse each line
+            m = re.match(r"(\d+\.?\d*)\s+(\d+\.?\d*)\s+(\d+\.?\d*)\s+\[([^]]*)]\s+(.*)", l)
+            if m:
+                raw_data.append(m.groups())
+        return raw_data
+
+    # find each cpu, gpu, npu block
+    def _find_all_platform_block(lines):
+        cur_start = None
+        cur_platform = None
+        platform_block = dict()
+        for i in range(len(lines)):
+            l = lines[i].strip()
+            # found start and end of a platform
+            if l.startswith("CPU") or l.startswith("GPU") or l.startswith("NPU"):
+                if cur_platform is not None:
+                    platform_block[cur_platform] = (cur_start, i)
+                cur_platform = l[:-1]
+                cur_start = i + 1
+                continue
+            if cur_platform is not None and i == len(lines) - 1:
+                platform_block[cur_platform] = (cur_start, i)
+        for key in platform_block:
+            r = platform_block[key]
+            platform_block[key] = _parse_benchmark_data(lines[r[0]:r[1]])
+
+        return platform_block
+
+    # find device block
+    def _find_all_device_block(lines, level):
+        cur_start = None
+        cur_device_name = None
+        device_block = dict()
+        for i in range(len(lines)):
+            l = lines[i].strip()
+            m = re.match(r"^(#+)\s+(.*)", l)
+            # found start and end of a device
+            if m and len(m.group(1)) == level:
+                if cur_device_name is not None:
+                    device_block[cur_device_name] = (cur_start, i)
+                cur_device_name = m.group(2)
+                cur_start = i + 1
+                continue
+            if cur_device_name is not None and i == len(lines) - 1:
+                device_block[cur_device_name] = (cur_start, i)
+
+        for key in device_block:
+            r = device_block[key]
+            device_block[key] = _find_all_platform_block(lines[r[0]:r[1]])
+
+        return device_block
+
+    # find detail block
+    def _find_detail_block(lines, title, level):
+        start = None
+        end = len(lines)
+        for i in range(len(lines)):
+            l = lines[i].strip()
+            m = re.match(r"^(#+)\s+(.*)", l)
+            # found start of detailed results block
+            if m and len(m.group(1)) == level and m.group(2) == title:
+                start = i + 1
+                continue
+            # found end of detailed results block
+            if start is not None and m and len(m.group(1)) <= level:
+                end = i
+                break
+
+        return _find_all_device_block(lines[start:end], level + 1)
+
     with open(filepath, "r", encoding="utf-8") as f:
         content = f.read()
     lines = content.split("\n")
 
-    header = []
-    body = []
+    devices = cfg["Devices"]
+    models = cfg["Models"]
+    # display information of all devices
+    devices_display = [x['display_info'] for x in cfg["Devices"]]
+    header = ["Model", "Task", "Input Size"] + devices_display
+    body = [[x["name"], x["task"], x["input_size"]] + ["---"] * len(devices) for x in models]
+    table_raw_data = _find_detail_block(lines, title="Detailed Results", level=2)
 
-    found_start = False  # if found table start line
-    parse_done = False  # if parse table done
-    for l in lines:
-        if found_start and parse_done:
-            break
-        l = l.strip()
-        if not l:
-            continue
-        if l.startswith("|") and l.endswith("|"):
-            if not found_start:
-                found_start = True
-            row = [c.strip() for c in l.split("|") if c.strip()]
-            if not header:
-                header = row
-            else:
-                body.append(row)
-        elif found_start:
-            parse_done = True
+    device_name_header = [f"{x['name']}-{x['platform']}" for x in devices]
+    device_name_header = [""] * (len(header) - len(device_name_header)) + device_name_header
+    # device name map to model col idx
+    device_name_to_col_idx = {k: v for v, k in enumerate(device_name_header)}
+    # model name map to model row idx
+    model_name_to_row_idx = {k[0]: v for v, k in enumerate(body)}
+    # convert raw data to usage data
+    for device in devices:
+        raw_data = table_raw_data[device["name"]][device["platform"]]
+        col_idx = device_name_to_col_idx[f"{device['name']}-{device['platform']}"]
+        for model in models:
+            # find which row idx of this model
+            row_idx = model_name_to_row_idx[model["name"]]
+            model_idxs = [i for i in range(len(raw_data)) if model["keyword"] in raw_data[i][-1]]
+            if len(model_idxs) > 0:
+                # only choose the first one
+                model_idx = model_idxs[0]
+                # choose mean as value
+                body[row_idx][col_idx] = raw_data[model_idx][0]
+                # remove used data
+            for idx in sorted(model_idxs, reverse=True):
+                raw_data.pop(idx)
+
+    # handle suffix
+    for suffix in cfg["Suffixes"]:
+        row_idx = model_name_to_row_idx[suffix["model"]]
+        col_idx = device_name_to_col_idx[f"{suffix['device']}-{suffix['platform']}"]
+        body[row_idx][col_idx] += suffix["str"]
+
     return header, body
 
 
-# parse models information
-def parse_data(models_info):
-    min_list = []
-    max_list = []
-    colors = []
-    for model in models_info:
-        # remove \*
-        data = [x.replace("\\*", "") for x in model]
-        # get max data
-        max_data = -1
-        max_idx = -1
-        min_data = 9999999
-        min_idx = -1
+# render table and save
+def render_table(header, body, save_path, cfg, cmap_type):
+    # parse models information and return some data
+    def _parse_data(models_info, cmap, cfg):
+        min_list = []
+        max_list = []
+        colors = []
+        # model name map to idx
+        model_name_to_idx = {k["name"]: v for v, k in enumerate(cfg["Models"])}
+        for model in models_info:
+            # remove \*
+            data = [x.replace("\\*", "") for x in model]
+            # get max data
+            max_idx = -1
+            min_data = 9999999
+            min_idx = -1
 
-        for i in range(len(data)):
-            try:
-                d = float(data[i])
-                if d > max_data:
-                    max_data = d
-                    max_idx = i
-                if d < min_data:
-                    min_data = d
-                    min_idx = i
-            except:
-                pass
+            for i in range(len(data)):
+                try:
+                    d = float(data[i])
+                    if d < min_data:
+                        min_data = d
+                        min_idx = i
+                except:
+                    pass
+            # set all bigger than acceptable time to red color
+            idx = model_name_to_idx[model[0]]
+            acc_time = cfg["Models"][idx]["acceptable_time"]
 
-        min_list.append(min_idx)
-        max_list.append(max_idx)
+            min_list.append(min_idx)
+            max_list.append(max_idx)
 
-        # calculate colors
-        color = []
-        for t in data:
-            try:
-                t = (float(t) - min_data) / (max_data - min_data)
-                color.append(cmap(t))
-            except:
-                color.append('white')
-        colors.append(color)
-    return colors, min_list, max_list
+            # calculate colors
+            color = []
+            for t in data:
+                try:
+                    t = float(t)
+                    if t > acc_time:
+                        # all bigger time will be set to red
+                        color.append(cmap(1.))
+                    else:
+                        # sqrt to make the result non-linear
+                        t = np.sqrt((t - min_data) / (acc_time - min_data))
+                        color.append(cmap(t))
+                except:
+                    color.append('white')
+            colors.append(color)
+        return colors, min_list, max_list
 
+    cmap = mpl.colormaps.get_cmap(cmap_type)
+    table_colors, min_list, max_list = _parse_data(body, cmap, cfg)
+    table_texts = [header] + body
+    table_colors = [['white'] * len(header)] + table_colors
 
-if __name__ == '__main__':
-    hardware_info, models_info = parse_table("./README.md")
-    cmap = mpl.colormaps.get_cmap("RdYlGn_r")
-    # remove empty line
-    models_info.pop(0)
-    # remove reference
-    hardware_info = [re.sub(r'\[(.+?)]\(.+?\)', r'\1', r) for r in hardware_info]
-    models_info = [[re.sub(r'\[(.+?)]\(.+?\)', r'\1', c) for c in r] for r in models_info]
-
-    table_colors, min_list, max_list = parse_data(models_info)
-    table_texts = [hardware_info] + models_info
-    table_colors = [['white'] * len(hardware_info)] + table_colors
-    # create a color bar. base width set to 1000, color map height set to 80
+    # create a figure, base width set to 1000, height set to 80
     fig, axs = plt.subplots(nrows=3, figsize=(10, 0.8))
+    # turn off labels and axis
+    for ax in axs:
+        ax.set_axis_off()
+        ax.set_xticks([])
+        ax.set_yticks([])
+
+    # create and add a color map
     gradient = np.linspace(0, 1, 256)
     gradient = np.vstack((gradient, gradient))
     axs[0].imshow(gradient, aspect='auto', cmap=cmap)
@@ -101,6 +200,24 @@ if __name__ == '__main__':
                          cellColours=table_colors,
                          cellLoc="left",
                          loc="upper left")
+    # set style of header, each url of hardware
+    ori_height = table[0, 0].get_height()
+    url_base = 'https://github.com/opencv/opencv_zoo/tree/master/benchmark#'
+    hw_urls = [f"{url_base}{x['name'].lower().replace(' ', '-')}" for x in cfg["Devices"]]
+    hw_urls = [""] * 3 + hw_urls
+    for col in range(len(header)):
+        cell = table[0, col]
+        cell.set_text_props(ha='center', weight='bold', linespacing=1.5, url=hw_urls[col])
+        cell.set_url(hw_urls[col])
+        cell.set_height(ori_height * 2.2)
+
+    url_base = 'https://github.com/opencv/opencv_zoo/tree/master/models/'
+    model_urls = [f"{url_base}{x['folder']}" for x in cfg["Models"]]
+    model_urls = [""] + model_urls
+    for row in range(len(body) + 1):
+        cell = table[row, 0]
+        cell.set_text_props(url=model_urls[row])
+        cell.set_url(model_urls[row])
 
     # adjust table position
     table_pos = axs[1].get_position()
@@ -122,24 +239,21 @@ if __name__ == '__main__':
         cell = table.get_celld()[(i + 1, min_list[i])]
         cell.set_text_props(weight='bold', color='white')
 
+    # draw table and trigger changing the column width value
+    fig.canvas.draw()
+    # calculate table height and width
     table_height = 0
     table_width = 0
-    # calculate table height and width
     for i in range(len(table_texts)):
         cell = table.get_celld()[(i, 0)]
         table_height += cell.get_height()
     for i in range(len(table_texts[0])):
         cell = table.get_celld()[(0, i)]
-        table_width += cell.get_width() + 0.1
+        table_width += cell.get_width()
 
     # add notes for table
-    axs[2].text(0, -table_height - 0.8, "\*: Models are quantized in per-channel mode, which run slower than per-tensor quantized models on NPU.", va='bottom', ha='left', fontsize=11, transform=axs[1].transAxes)
-
-    # turn off labels
-    for ax in axs:
-        ax.set_axis_off()
-        ax.set_xticks([])
-        ax.set_yticks([])
+    axs[2].text(0, -table_height - 1, "Units: All data in milliseconds (ms).", va='bottom', ha='left', fontsize=11, transform=axs[1].transAxes)
+    axs[2].text(0, -table_height - 2, "\\*: Models are quantized in per-channel mode, which run slower than per-tensor quantized models on NPU.", va='bottom', ha='left', fontsize=11, transform=axs[1].transAxes)
 
     # adjust color map position to center
     cm_pos = axs[0].get_position()
@@ -151,4 +265,13 @@ if __name__ == '__main__':
     ])
 
     plt.rcParams['svg.fonttype'] = 'none'
-    plt.savefig("./color_table.svg", format='svg', bbox_inches="tight", pad_inches=0, metadata={'Date': None, 'Creator': None})
+    plt.rcParams['svg.hashsalt'] = '11'  # fix hash salt for avoiding id change
+    plt.savefig(save_path, format='svg', bbox_inches="tight", pad_inches=0, metadata={'Date': None, 'Creator': None})
+
+
+if __name__ == '__main__':
+    with open("table_config.yaml", 'r') as f:
+        cfg = yaml.safe_load(f)
+
+    hw_info, model_info = parse_table("README.md", cfg)
+    render_table(hw_info, model_info, "color_table.svg", cfg, "RdYlGn_r")

--- a/benchmark/table_config.yaml
+++ b/benchmark/table_config.yaml
@@ -1,0 +1,219 @@
+#  model information
+#  - name: model name, used for display
+#    task: model task, used for display
+#    input_size: input size, used for display
+#    folder: which folder the model located in, used for jumping to model detail
+#    acceptable_time: maximum acceptable inference time, large ones will be marked red
+#    keyword: used to specify this model from all benchmark results
+#
+#  device information
+#  - name: full device name used to identify the device block, and jump to device detail
+#    display_info: device information for display
+#    platform: used to identify benchmark result of specific platform
+#
+#  suffix information
+#  - model: which model
+#    device: which device
+#    suffix: this suffix will be appended to end of this text
+
+Models:
+  - name: "YuNet"
+    task: "Face Detection"
+    input_size: "160x120"
+    folder: "face_detection_yunet"
+    acceptable_time: 50
+    keyword: "face_detection_yunet"
+
+  - name: "SFace"
+    task: "Face Recognition"
+    input_size: "112x112"
+    folder: "face_recognition_sface"
+    acceptable_time: 200
+    keyword: "face_recognition_sface"
+
+  - name: "FER"
+    task: "Face Expression Recognition"
+    input_size: "112x112"
+    folder: "facial_expression_recognition"
+    acceptable_time: 200
+    keyword: "facial_expression_recognition_mobilefacenet"
+
+  - name: "LPD_YuNet"
+    task: "License Plate Detection"
+    input_size: "320x240"
+    folder: "license_plate_detection_yunet"
+    acceptable_time: 700
+    keyword: "license_plate_detection_lpd_yunet"
+
+  - name: "YOLOX"
+    task: "Object Detection"
+    input_size: "640x640"
+    folder: "object_detection_yolox"
+    acceptable_time: 2800
+    keyword: "object_detection_yolox"
+
+  - name: "NanoDet"
+    task: "Object Detection"
+    input_size: "416x416"
+    folder: "object_detection_nanodet"
+    acceptable_time: 2000
+    keyword: "object_detection_nanodet"
+
+  - name: "DB-IC15 (EN)"
+    task: "Text Detection"
+    input_size: "640x480"
+    folder: "text_detection_db"
+    acceptable_time: 2000
+    keyword: "text_detection_DB_IC15_resnet18"
+
+  - name: "DB-TD500 (EN&CN)"
+    task: "Text Detection"
+    input_size: "640x480"
+    folder: "text_detection_db"
+    acceptable_time: 2000
+    keyword: "text_detection_DB_TD500_resnet18"
+
+  - name: "CRNN-EN"
+    task: "Text Recognition"
+    input_size: "100*32"
+    folder: "text_recognition_crnn"
+    acceptable_time: 2000
+    keyword: "text_recognition_CRNN_EN"
+
+  - name: "CRNN-CN"
+    task: "Text Recognition"
+    input_size: "100*32"
+    folder: "text_recognition_crnn"
+    acceptable_time: 2000
+    keyword: "text_recognition_CRNN_CN"
+
+  - name: "PP-ResNet"
+    task: "Image Classification"
+    input_size: "224x224"
+    folder: "image_classification_ppresnet"
+    acceptable_time: 1000
+    keyword: "image_classification_ppresnet50"
+
+  - name: "MobileNet-V1"
+    task: "Image Classification"
+    input_size: "224x224"
+    folder: "image_classification_mobilenet"
+    acceptable_time: 500
+    keyword: "image_classification_mobilenetv1"
+
+  - name: "MobileNet-V2"
+    task: "Image Classification"
+    input_size: "224x224"
+    folder: "image_classification_mobilenet"
+    acceptable_time: 500
+    keyword: "image_classification_mobilenetv2"
+
+  - name: "PP-HumanSeg"
+    task: "Human Segmentation"
+    input_size: "192x192"
+    folder: "human_segmentation_pphumanseg"
+    acceptable_time: 700
+    keyword: "human_segmentation_pphumanseg"
+
+  - name: "WeChatQRCode"
+    task: "QR Code Detection and Parsing"
+    input_size: "100x100"
+    folder: "qrcode_wechatqrcode"
+    acceptable_time: 100
+    keyword: "WeChatQRCode"
+
+  - name: "DaSiamRPN"
+    task: "Object Tracking"
+    input_size: "1280x720"
+    folder: "object_tracking_dasiamrpn"
+    acceptable_time: 3000
+    keyword: "object_tracking_dasiamrpn"
+
+  - name: "YoutuReID"
+    task: "Person Re-Identification"
+    input_size: "128x256"
+    folder: "person_reid_youtureid"
+    acceptable_time: 800
+    keyword: "person_reid_youtu"
+
+  - name: "MP-PalmDet"
+    task: "Palm Detection"
+    input_size: "192x192"
+    folder: "palm_detection_mediapipe"
+    acceptable_time: 500
+    keyword: "palm_detection_mediapipe"
+
+  - name: "MP-HandPose"
+    task: "Hand Pose Estimation"
+    input_size: "224x224"
+    folder: "handpose_estimation_mediapipe"
+    acceptable_time: 500
+    keyword: "handpose_estimation_mediapipe"
+
+  - name: "MP-PersonDet"
+    task: "Person Detection"
+    input_size: "224x224"
+    folder: "person_detection_mediapipe"
+    acceptable_time: 1300
+    keyword: "person_detection_mediapipe"
+
+
+Devices:
+  - name: "Intel 12700K"
+    display_info: "Intel\n12700K\nCPU"
+    platform: "CPU"
+
+  - name: "Rasberry Pi 4B"
+    display_info: "Rasberry Pi 4B\nBCM2711\nCPU"
+    platform: "CPU"
+
+  - name: "Toybrick RV1126"
+    display_info: "Toybrick\nRV1126\nCPU"
+    platform: "CPU"
+
+  - name: "Khadas Edge2 (with RK3588)"
+    display_info: "Khadas Edge2\nRK3588S\nCPU"
+    platform: "CPU"
+
+  - name: "Horizon Sunrise X3 PI"
+    display_info: "Horizon Sunrise Pi\nX3\nCPU"
+    platform: "CPU"
+
+  - name: "MAIX-III AX-PI"
+    display_info: "MAIX-III AX-Pi\nAX620A\nCPU"
+    platform: "CPU"
+
+  - name: "Jetson Nano B01"
+    display_info: "Jetson Nano\nB01\nCPU"
+    platform: "CPU"
+
+  - name: "Khadas VIM3"
+    display_info: "Khadas VIM3\nA311D\nCPU"
+    platform: "CPU"
+
+  - name: "Atlas 200 DK"
+    display_info: "Atlas 200 DK\nAscend 310\nCPU"
+    platform: "CPU"
+
+  - name: "Jetson Nano B01"
+    display_info: "Jetson Nano\nB01\nGPU"
+    platform: "GPU (CUDA-FP32)"
+
+  - name: "Khadas VIM3"
+    display_info: "Khadas VIM3\nA311D\nNPU"
+    platform: "NPU (TIMVX)"
+
+  - name: "Atlas 200 DK"
+    display_info: "Atlas 200 DK\nAscend 310\nNPU"
+    platform: "NPU"
+
+Suffixes:
+  - model: "MobileNet-V1"
+    device: "Khadas VIM3"
+    platform: "NPU (TIMVX)"
+    str: "\\*"
+
+  - model: "MobileNet-V2"
+    device: "Khadas VIM3"
+    platform: "NPU (TIMVX)"
+    str: "\\*"


### PR DESCRIPTION
Update the color table:
- Automatically parse table data based on benchmark results
- Remove `(ms)` from the header
- Make color changes non-linear
- Header device direct to detail url
- Models name direct to detail url
- Split device companpy from device mdoel
- Make header text bold and center alignment
- Make color map be in the center of the table
- Add a config file for the parser:
  - acceptable_time: values greater than this will be set to red. I use the value of 100 times the best result
  - need other information for the parser

TODO: need @fengyuentau rename devices display_info
