### PR TITLE
Add back CRNN FP16 models as git-lfs tracked files

### DIFF
--- a/models/text_recognition_crnn/text_recognition_CRNN_CH_2023feb_fp16.onnx
+++ b/models/text_recognition_crnn/text_recognition_CRNN_CH_2023feb_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfef028889b3a21771e687d501ac38ccab6d37d199e94f244d60cc21f743526b
+size 32472394

--- a/models/text_recognition_crnn/text_recognition_CRNN_EN_2023feb_fp16.onnx
+++ b/models/text_recognition_crnn/text_recognition_CRNN_EN_2023feb_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e785f79aeb817e1600b18fad5e740bddc281a9eb053d648f163af335a32d59d0
+size 16916177


### PR DESCRIPTION
Part two of https://github.com/opencv/opencv_zoo/issues/165