### PR TITLE
Quantize all models to fp16

### DIFF
--- a/models/face_detection_yunet/face_detection_yunet_2023mar_fp16.onnx
+++ b/models/face_detection_yunet/face_detection_yunet_2023mar_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1263d26b9e56d9e7431e4f868b4c4caa362653fb220f2aff240dc5270091a50b
+size 126333

--- a/models/face_recognition_sface/face_recognition_sface_2021dec_fp16.onnx
+++ b/models/face_recognition_sface/face_recognition_sface_2021dec_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6abbfff9575e3041db692c1e29d782e995191888477fd59ebc81202d99fc63b
+size 24227283

--- a/models/facial_expression_recognition/facial_expression_recognition_mobilefacenet_2022july_fp16.onnx
+++ b/models/facial_expression_recognition/facial_expression_recognition_mobilefacenet_2022july_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6bd51e7dca0c2bfb3755e7884e69f6c6810fbad9e53f9d75a597add3baed1a8
+size 2413209

--- a/models/handpose_estimation_mediapipe/handpose_estimation_mediapipe_2023feb_fp16.onnx
+++ b/models/handpose_estimation_mediapipe/handpose_estimation_mediapipe_2023feb_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:febfac55f789674c38eee023c369de4f1c57ab592a699781e87d89b54a6d4189
+size 2076178

--- a/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar_fp16.onnx
+++ b/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9f359bc3d50bf0bcf20762076b1cd174a431bb404149f482a2fccb8e5131628
+size 3099693

--- a/models/image_classification_mobilenet/image_classification_mobilenetv1_2022apr_fp16.onnx
+++ b/models/image_classification_mobilenet/image_classification_mobilenetv1_2022apr_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de99f3c6c92af11876ee21545701010876c9c0ec4f75d9bfbd5b5adccd516f8e
+size 8449898

--- a/models/image_classification_mobilenet/image_classification_mobilenetv2_2022apr_fp16.onnx
+++ b/models/image_classification_mobilenet/image_classification_mobilenetv2_2022apr_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:823ed99e25277696d79279f5866c138d1a04722409b02869c512d4a7a64d6006
+size 6992958

--- a/models/image_classification_ppresnet/image_classification_ppresnet50_2022jan_fp16.onnx
+++ b/models/image_classification_ppresnet/image_classification_ppresnet50_2022jan_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17f32c5716fe2d6073164a3e677981e5e2b82f57e61d8fa49ee779f6a0fef7b8
+size 65414918

--- a/models/license_plate_detection_yunet/license_plate_detection_lpd_yunet_2023mar_fp16.onnx
+++ b/models/license_plate_detection_yunet/license_plate_detection_lpd_yunet_2023mar_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31a621b3f88b90fade3f51e6060883e65d5410e6de53a6dea1888f6569f07bf4
+size 2080376

--- a/models/object_detection_nanodet/object_detection_nanodet_2022nov_fp16.onnx
+++ b/models/object_detection_nanodet/object_detection_nanodet_2022nov_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d26642c6c74864504fb5487821ca93dcb6a497629da4556ead4c51b7a52edcd
+size 1917291

--- a/models/object_detection_yolox/object_detection_yolox_2022nov_fp16.onnx
+++ b/models/object_detection_yolox/object_detection_yolox_2022nov_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ccec6eb86a17cf88f161aaf26dd56d333e3fbeb1b370eb9cb70c3dd12432d36
+size 17944560

--- a/models/object_tracking_dasiamrpn/object_tracking_dasiamrpn_kernel_cls1_2021nov_fp16.onnx
+++ b/models/object_tracking_dasiamrpn/object_tracking_dasiamrpn_kernel_cls1_2021nov_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62114adf1dbe41461593ea4aa435ce4b7cd4a8ee3a12a01e383698e1f4817620
+size 11801998

--- a/models/object_tracking_dasiamrpn/object_tracking_dasiamrpn_kernel_r1_2021nov_fp16.onnx
+++ b/models/object_tracking_dasiamrpn/object_tracking_dasiamrpn_kernel_r1_2021nov_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fba5bee6ed8c907b194594ad04c82385cd8076a2361170a41dbccafec05b55b
+size 23603586

--- a/models/object_tracking_dasiamrpn/object_tracking_dasiamrpn_model_2021nov_fp16.onnx
+++ b/models/object_tracking_dasiamrpn/object_tracking_dasiamrpn_model_2021nov_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:069198aff29984c381dcea84558ba60a75d851aac9310ebe52db5f9dda105608
+size 45524342

--- a/models/palm_detection_mediapipe/palm_detection_mediapipe_2023feb_fp16.onnx
+++ b/models/palm_detection_mediapipe/palm_detection_mediapipe_2023feb_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0843d197c6820c489e71081021823d57849032269b497994bef8682c530701d
+size 1985511

--- a/models/person_detection_mediapipe/person_detection_mediapipe_2023mar_fp16.onnx
+++ b/models/person_detection_mediapipe/person_detection_mediapipe_2023mar_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fd42391028c48039af68baceae5733f3a3bd31241f887770b96678228e151df
+size 6060089

--- a/models/person_reid_youtureid/person_reid_youtu_2021nov_fp16.onnx
+++ b/models/person_reid_youtureid/person_reid_youtu_2021nov_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:756e85946fe83d8269c8543f7b46290c87a43477758b08097cbcae7c4d654132
+size 53466034

--- a/models/pose_estimation_mediapipe/pose_estimation_mediapipe_2023mar_fp16.onnx
+++ b/models/pose_estimation_mediapipe/pose_estimation_mediapipe_2023mar_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:449de123d2157d94db1a123e5943ba28e54ae50ffd72b13d9154f447f65f1836
+size 2831020

--- a/models/text_detection_db/text_detection_DB_IC15_resnet18_2021sep_fp16.onnx
+++ b/models/text_detection_db/text_detection_DB_IC15_resnet18_2021sep_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62324d714056a4ce621e3ca5458c83be12ce8ba3cb0114ce2ee4fb29e616c7b8
+size 24404916

--- a/models/text_detection_db/text_detection_DB_TD500_resnet18_2021sep_fp16.onnx
+++ b/models/text_detection_db/text_detection_DB_TD500_resnet18_2021sep_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a52ff8fb7c1a3bd56463ad997ca845a80451adfc5421da43f61e540ae6aafe98
+size 24404916

--- a/models/text_recognition_crnn/text_recognition_CRNN_CH_2021sep_fp16.onnx
+++ b/models/text_recognition_crnn/text_recognition_CRNN_CH_2021sep_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a51fa1e4155f9a68439869c7187f0ccda3a8ffce7abdb23da75c225b1c9b5fe4
+size 32472431

--- a/models/text_recognition_crnn/text_recognition_CRNN_CN_2021nov_fp16.onnx
+++ b/models/text_recognition_crnn/text_recognition_CRNN_CN_2021nov_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acff153535e41702c14c62a41f5d09df7e28459b46525372e1a60c4cd309285d
+size 36422522

--- a/models/text_recognition_crnn/text_recognition_CRNN_EN_2021sep_fp16.onnx
+++ b/models/text_recognition_crnn/text_recognition_CRNN_EN_2021sep_fp16.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1269b01d544cccb4e4c61b8a7a209b6643ef4ce969432ca963ce78f093138c2a
+size 16918127

--- a/tools/quantize/fp16-quantize-ort.py
+++ b/tools/quantize/fp16-quantize-ort.py
@@ -1,0 +1,60 @@
+import sys
+import onnx
+from onnxconverter_common import float16
+
+op_block_list = ['ArrayFeatureExtractor', 'Binarizer', 'CastMap', 'CategoryMapper', 'DictVectorizer',
+                 'FeatureVectorizer', 'Imputer', 'LabelEncoder', 'LinearClassifier', 'LinearRegressor',
+                 'Normalizer', 'OneHotEncoder', 'RandomUniformLike', 'SVMClassifier', 'SVMRegressor', 'Scaler',
+                 'TreeEnsembleClassifier', 'TreeEnsembleRegressor', 'ZipMap', 'NonMaxSuppression', 'TopK',
+                 'RoiAlign', 'Range', 'CumSum', 'Min', 'Max', 'Upsample']
+
+
+class Quantize:
+    def __init__(self, model_path):
+        self.model_path = model_path
+
+    def run(self):
+        model = onnx.load(self.model_path)
+        model_fp16 = float16.convert_float_to_float16(model, op_block_list=op_block_list)
+        output_name = '{}_fp16.onnx'.format(self.model_path[:-5])
+        onnx.save(model_fp16, output_name)
+
+
+models = dict(
+    yunet=Quantize(model_path='../../models/face_detection_yunet/face_detection_yunet_2023mar.onnx'),
+    sface=Quantize(model_path='../../models/face_recognition_sface/face_recognition_sface_2021dec.onnx'),
+    fer=Quantize(model_path='../../models/facial_expression_recognition/facial_expression_recognition_mobilefacenet_2022july.onnx'),
+    pphumanseg=Quantize(model_path='../../models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar.onnx'),
+    mobilenetv1=Quantize(model_path='../../models/image_classification_mobilenet/image_classification_mobilenetv1_2022apr.onnx'),
+    mobilenetv2=Quantize(model_path='../../models/image_classification_mobilenet/image_classification_mobilenetv2_2022apr.onnx'),
+    ppresnet50=Quantize(model_path='../../models/image_classification_ppresnet/image_classification_ppresnet50_2022jan.onnx'),
+    nanodet=Quantize(model_path='../../models/object_detection_nanodet/object_detection_nanodet_2022nov.onnx'),
+    yolox=Quantize(model_path='../../models/object_detection_yolox/object_detection_yolox_2022nov.onnx'),
+    dasiamrpn=Quantize(model_path='../../models/object_tracking_dasiamrpn/object_tracking_dasiamrpn_model_2021nov.onnx'),
+    dasiamrpn_cls1=Quantize(model_path='../../models/object_tracking_dasiamrpn/object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx'),
+    dasiamrpn_r1=Quantize(model_path='../../models/object_tracking_dasiamrpn/object_tracking_dasiamrpn_kernel_r1_2021nov.onnx'),
+    youtureid=Quantize(model_path='../../models/person_reid_youtureid/person_reid_youtu_2021nov.onnx'),
+    mp_palmdet=Quantize(model_path='../../models/palm_detection_mediapipe/palm_detection_mediapipe_2023feb.onnx'),
+    mp_handpose=Quantize(model_path='../../models/handpose_estimation_mediapipe/handpose_estimation_mediapipe_2023feb.onnx'),
+    lpd_yunet=Quantize(model_path='../../models/license_plate_detection_yunet/license_plate_detection_lpd_yunet_2023mar.onnx'),
+    mp_persondet=Quantize(model_path='../../models/person_detection_mediapipe/person_detection_mediapipe_2023mar.onnx'),
+    mp_pose=Quantize(model_path='../../models/pose_estimation_mediapipe/pose_estimation_mediapipe_2023mar.onnx'),
+    db_en=Quantize(model_path='../../models/text_detection_db/text_detection_DB_IC15_resnet18_2021sep.onnx'),
+    db_ch=Quantize(model_path='../../models/text_detection_db/text_detection_DB_TD500_resnet18_2021sep.onnx'),
+    crnn_en=Quantize(model_path='../../models/text_recognition_crnn/text_recognition_CRNN_EN_2021sep.onnx'),
+    crnn_ch=Quantize(model_path='../../models/text_recognition_crnn/text_recognition_CRNN_CH_2021sep.onnx'),
+    crnn_cn=Quantize(model_path='../../models/text_recognition_crnn/text_recognition_CRNN_CN_2021nov.onnx')
+)
+
+if __name__ == '__main__':
+    selected_models = []
+    for i in range(1, len(sys.argv)):
+        selected_models.append(sys.argv[i])
+    if not selected_models:
+        selected_models = list(models.keys())
+    print('Models to be quantized to fp16: {}'.format(str(selected_models)))
+
+    for selected_model_name in selected_models:
+        q = models[selected_model_name]
+        print("------------------{}------------------".format(selected_model_name))
+        q.run()

--- a/tools/quantize/requirements.txt
+++ b/tools/quantize/requirements.txt
@@ -3,3 +3,4 @@ onnx
 onnxruntime
 onnxruntime-extensions
 neural-compressor
+onnxconverter-common


### PR DESCRIPTION
This PR try to quantize all the models from `float32` to `float16`. Accuracy evaluation results show they have almost same performance.

| Models | Dataset | fp32 acc | fp16 acc |
|-|-|-|-|
| YuNet | WIDERFace| 0.88437(E), 0.86560(M), 0.75030(H) | 0.88425(E), 0.86558(M), 0.75018(H) |
| MobileNet V1| imagenet | 0.6773(Top1), 0.8797(Top5) | 0.6774(Top1), 0.88(Top5)|
| MobileNet V2| imagenet | 0.6953(Top1), 0.8923(Top5) | 0.6952(Top1), 0.8923(Top5)|
| PPResnet | imagenet | 0.8238(Top1), 0.9615(Top5) | 0.8238(Top1), 0.9615(Top5)|
| SFace | LFW | 0.9940 | 0.9940 |
| PPHumanSeg| mini supervisely | 0.91642(IoU), 0.96558(Acc) | 0.91641(IoU), 0.96557(Acc)|
| CRNN | ICDAR 2003| 0.8166 | 0.8201 |
| CRNN | IIIT5K | 0.7433 | 0.7493 |

 
  
 