### PR TITLE
Fix OpenCV version assertions in ViTTrack & RAFT and text offset

### DIFF
--- a/models/object_tracking_vittrack/demo.py
+++ b/models/object_tracking_vittrack/demo.py
@@ -9,7 +9,7 @@ import cv2 as cv
 from vittrack import VitTrack
 
 # Check OpenCV version
-assert cv.__version__ > "4.9.0", \
+assert cv.__version__ >= "4.9.0", \
        "Please install latest opencv-python to try this demo: python3 -m pip install --upgrade opencv-python"
 
 # Valid combinations of backends and targets

--- a/models/object_tracking_vittrack/demo.py
+++ b/models/object_tracking_vittrack/demo.py
@@ -52,7 +52,7 @@ def visualize(image, bbox, score, isLocated, fps=None, box_color=(0, 255, 0),tex
         # bbox: Tuple of length 4
         x, y, w, h = bbox
         cv.rectangle(output, (x, y), (x+w, y+h), box_color, 2)
-        cv.putText(output, '{:.2f}'.format(score), (x, y+20), cv.FONT_HERSHEY_DUPLEX, fontScale, text_color, fontSize)
+        cv.putText(output, '{:.2f}'.format(score), (x, y+25), cv.FONT_HERSHEY_DUPLEX, fontScale, text_color, fontSize)
     else:
         text_size, baseline = cv.getTextSize('Target lost!', cv.FONT_HERSHEY_DUPLEX, fontScale, fontSize)
         text_x = int((w - text_size[0]) / 2)

--- a/models/optical_flow_estimation_raft/demo.py
+++ b/models/optical_flow_estimation_raft/demo.py
@@ -6,7 +6,7 @@ import numpy as np
 from raft import Raft
 
 # Check OpenCV version
-assert cv.__version__ > "4.9.0", \
+assert cv.__version__ >= "4.9.0", \
        "Please install latest opencv-python to try this demo: python3 -m pip install --upgrade opencv-python"
 
 parser = argparse.ArgumentParser(description='RAFT (https://github.com/princeton-vl/RAFT)')


### PR DESCRIPTION
This PR addresses compatibility issues with OpenCV version 4.9.0 by updating assertions in the code. Issue was pointed out in https://github.com/opencv/opencv_zoo/issues/135#issuecomment-1962323969. 

Additionally, a minor adjustment has been made to increase the offset, preventing the confidence text from overlapping with the bounding box border.
![image](https://github.com/opencv/opencv_zoo/assets/43348991/f43d52d8-8bb5-4e62-993b-93b93a1f1ef5)
