### PR TITLE
Introduce Preprocessing for Optimized Quantization in `quantize-ort.py`

### DIFF
--- a/tools/quantize/quantize-ort.py
+++ b/tools/quantize/quantize-ort.py
@@ -77,7 +77,7 @@ class Quantize:
         print('Quantizing {}: act_type {}, wt_type {}'.format(self.model_path, self.act_type, self.wt_type))
         new_model_path = self.check_opset()
         quant_pre_process(new_model_path, new_model_path)
-        output_name = '{}_{}_new.onnx'.format(self.model_path[:-5], self.wt_type)
+        output_name = '{}_{}.onnx'.format(self.model_path[:-5], self.wt_type)
         quantize_static(new_model_path, output_name, self.dr,
                         quant_format=QuantFormat.QOperator, # start from onnxruntime==1.11.0, quant_format is set to QuantFormat.QDQ by default, which performs fake quantization
                         per_channel=self.per_channel,

--- a/tools/quantize/quantize-ort.py
+++ b/tools/quantize/quantize-ort.py
@@ -12,7 +12,7 @@ import cv2 as cv
 import onnx
 from onnx import version_converter
 import onnxruntime
-from onnxruntime.quantization import quantize_static, CalibrationDataReader, QuantType, QuantFormat
+from onnxruntime.quantization import quantize_static, CalibrationDataReader, QuantType, QuantFormat, quant_pre_process
 
 from transform import Compose, Resize, CenterCrop, Normalize, ColorConvert, HandAlign
 
@@ -76,7 +76,8 @@ class Quantize:
     def run(self):
         print('Quantizing {}: act_type {}, wt_type {}'.format(self.model_path, self.act_type, self.wt_type))
         new_model_path = self.check_opset()
-        output_name = '{}_{}.onnx'.format(self.model_path[:-5], self.wt_type)
+        quant_pre_process(new_model_path, new_model_path)
+        output_name = '{}_{}_new.onnx'.format(self.model_path[:-5], self.wt_type)
         quantize_static(new_model_path, output_name, self.dr,
                         quant_format=QuantFormat.QOperator, # start from onnxruntime==1.11.0, quant_format is set to QuantFormat.QDQ by default, which performs fake quantization
                         per_channel=self.per_channel,


### PR DESCRIPTION
### Issues

Resolve #239

Running the quantization script `quantize-ort.py` cannot reproduce the quantized model in the repo. The current script will produce int8 quantized ppresnet50 at a size of over 120 MB, which is significantly different from the existing quantized models in the repo at the size of ~26 MB. After some investigation, I think the reason might be that preprocessing is missing. [The ONNX documentation](https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#qdqdebug) seems to suggest preprocessing is highly encouraged.

Left: Computation graph of already quantized models in the repo or models quantized by the updated script.
Right: Computation graph of the model quantized by the original script.<br>
<img width="500" alt="Screenshot 2024-02-26 at 23 15 36" src="https://github.com/opencv/opencv_zoo/assets/61866948/a7955877-bf40-47a9-812e-7233d8b0fa4d">

We can see that the current script will result in a model with an unoptimized computation graph and redundant computation nodes.

**Key Changes**
- A preprocessing step is added in `quantize-ort.py`. Optimization is automatically carried out by the `quant_pre_process` method.

**Expected Benefits**
- Running the updated script should allow us to reproduce the quantized models already in the repo.
