### PR TITLE
Bugfix: Crash during Evaluation of Yunet on Widerface Dataset

### DIFF
--- a/models/face_detection_yunet/yunet.py
+++ b/models/face_detection_yunet/yunet.py
@@ -52,4 +52,4 @@ class YuNet:
     def infer(self, image):
         # Forward
         faces = self._model.detect(image)
-        return np.array([]) if faces[1] is None else faces[1]
+        return np.empty(shape=(0, 5)) if faces[1] is None else faces[1]


### PR DESCRIPTION
With the current opencv-python and numpy packages. Executing the eval script will crash with error:

```
"...\datasets\widerface.py", line 305, in eval
    det = np.append(np.around(det[:, :4], 1), np.around(det[:, -1], 3).reshape(-1, 1), axis=1)
                                                        ~~~^^^^^^^
IndexError: index -1 is out of bounds for axis 1 with size 0
```

The returning `np.empty(shape=(0, 5))` instead of `np.arrayy([])` for empty detections will fix this.