### PR TITLE
fixing NMSBoxesBatched function accepts Rect objects instead of two diagonal corner coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ***This Project is now hosted in Hugging Face. Check https://huggingface.co/opencv to get models and online demos!***
+
 # OpenCV Zoo and Benchmark
 
 A zoo for models tuned for OpenCV DNN with benchmarks on different platforms.

--- a/models/object_detection_yolox/demo.cpp
+++ b/models/object_detection_yolox/demo.cpp
@@ -104,18 +104,18 @@ public:
             boxes.rowRange(r, r + 1) = *ptr * boxes.rowRange(r, r + 1);
         }
         // get boxes
-        Mat boxes_xyxy(boxes.rows, boxes.cols, CV_32FC1, Scalar(1));
+        Mat boxes_xywh(boxes.rows, boxes.cols, CV_32FC1, Scalar(1));
         Mat scores = dets.colRange(5, dets.cols).clone();
         vector<float> maxScores(dets.rows);
         vector<int> maxScoreIdx(dets.rows);
-        vector<Rect2d> boxesXYXY(dets.rows);
+        vector<Rect2d> boxesXYWH(dets.rows);
 
-        for (int r = 0; r < boxes_xyxy.rows; r++, ptr++)
+        for (int r = 0; r < boxes_xywh.rows; r++, ptr++)
         {
-            boxes_xyxy.at<float>(r, 0) = boxes.at<float>(r, 0) - boxes.at<float>(r, 2) / 2.f;
-            boxes_xyxy.at<float>(r, 1) = boxes.at<float>(r, 1) - boxes.at<float>(r, 3) / 2.f;
-            boxes_xyxy.at<float>(r, 2) = boxes.at<float>(r, 0) + boxes.at<float>(r, 2) / 2.f;
-            boxes_xyxy.at<float>(r, 3) = boxes.at<float>(r, 1) + boxes.at<float>(r, 3) / 2.f;
+            boxes_xywh.at<float>(r, 0) = boxes.at<float>(r, 0) - boxes.at<float>(r, 2) / 2.f;
+            boxes_xywh.at<float>(r, 1) = boxes.at<float>(r, 1) - boxes.at<float>(r, 3) / 2.f;
+            boxes_xywh.at<float>(r, 2) = boxes.at<float>(r, 2);
+            boxes_xywh.at<float>(r, 3) = boxes.at<float>(r, 3);
             // get scores and class indices
             scores.rowRange(r, r + 1) = scores.rowRange(r, r + 1) * dets.at<float>(r, 4);
             double minVal, maxVal;
@@ -123,19 +123,19 @@ public:
             minMaxLoc(scores.rowRange(r, r+1), &minVal, &maxVal, nullptr, &maxIdx);
             maxScoreIdx[r] = maxIdx.x;
             maxScores[r] = float(maxVal);
-            boxesXYXY[r].x = boxes_xyxy.at<float>(r, 0);
-            boxesXYXY[r].y = boxes_xyxy.at<float>(r, 1);
-            boxesXYXY[r].width = boxes_xyxy.at<float>(r, 2);
-            boxesXYXY[r].height = boxes_xyxy.at<float>(r, 3);
+            boxesXYWH[r].x = boxes_xywh.at<float>(r, 0);
+            boxesXYWH[r].y = boxes_xywh.at<float>(r, 1);
+            boxesXYWH[r].width = boxes_xywh.at<float>(r, 2);
+            boxesXYWH[r].height = boxes_xywh.at<float>(r, 3);
         }
 
         vector<int> keep;
-        NMSBoxesBatched(boxesXYXY, maxScores, maxScoreIdx, this->confThreshold, this->nmsThreshold, keep);
+        NMSBoxesBatched(boxesXYWH, maxScores, maxScoreIdx, this->confThreshold, this->nmsThreshold, keep);
         Mat candidates(int(keep.size()), 6, CV_32FC1);
         int row = 0;
         for (auto idx : keep)
         {
-            boxes_xyxy.rowRange(idx, idx + 1).copyTo(candidates(Rect(0, row, 4, 1)));
+            boxes_xywh.rowRange(idx, idx + 1).copyTo(candidates(Rect(0, row, 4, 1)));
             candidates.at<float>(row, 4) = maxScores[idx];
             candidates.at<float>(row, 5) = float(maxScoreIdx[idx]);
             row++;

--- a/models/object_detection_yolox/demo.cpp
+++ b/models/object_detection_yolox/demo.cpp
@@ -1,6 +1,6 @@
+#include <vector>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include <opencv2/opencv.hpp>
 
@@ -8,30 +8,28 @@ using namespace std;
 using namespace cv;
 using namespace dnn;
 
-vector<pair<dnn::Backend, dnn::Target>> backendTargetPairs = {
-    std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_OPENCV, dnn::DNN_TARGET_CPU),
-    std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CUDA, dnn::DNN_TARGET_CUDA),
-    std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CUDA, dnn::DNN_TARGET_CUDA_FP16),
-    std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_TIMVX, dnn::DNN_TARGET_NPU),
-    std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CANN, dnn::DNN_TARGET_NPU)
-};
+vector< pair<dnn::Backend, dnn::Target> > backendTargetPairs = {
+        std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_OPENCV, dnn::DNN_TARGET_CPU),
+        std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CUDA, dnn::DNN_TARGET_CUDA),
+        std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CUDA, dnn::DNN_TARGET_CUDA_FP16),
+        std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_TIMVX, dnn::DNN_TARGET_NPU),
+        std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CANN, dnn::DNN_TARGET_NPU) };
 
 vector<string> labelYolox = {
-    "person", "bicycle", "car", "motorcycle", "airplane", "bus",
-    "train", "truck", "boat", "traffic light", "fire hydrant",
-    "stop sign", "parking meter", "bench", "bird", "cat", "dog",
-    "horse", "sheep", "cow", "elephant", "bear", "zebra", "giraffe",
-    "backpack", "umbrella", "handbag", "tie", "suitcase", "frisbee",
-    "skis", "snowboard", "sports ball", "kite", "baseball bat",
-    "baseball glove", "skateboard", "surfboard", "tennis racket",
-    "bottle", "wine glass", "cup", "fork", "knife", "spoon", "bowl",
-    "banana", "apple", "sandwich", "orange", "broccoli", "carrot",
-    "hot dog", "pizza", "donut", "cake", "chair", "couch",
-    "potted plant", "bed", "dining table", "toilet", "tv", "laptop",
-    "mouse", "remote", "keyboard", "cell phone", "microwave",
-    "oven", "toaster", "sink", "refrigerator", "book", "clock",
-    "vase", "scissors", "teddy bear", "hair drier", "toothbrush"
-};
+        "person", "bicycle", "car", "motorcycle", "airplane", "bus",
+        "train", "truck", "boat", "traffic light", "fire hydrant",
+        "stop sign", "parking meter", "bench", "bird", "cat", "dog",
+        "horse", "sheep", "cow", "elephant", "bear", "zebra", "giraffe",
+        "backpack", "umbrella", "handbag", "tie", "suitcase", "frisbee",
+        "skis", "snowboard", "sports ball", "kite", "baseball bat",
+        "baseball glove", "skateboard", "surfboard", "tennis racket",
+        "bottle", "wine glass", "cup", "fork", "knife", "spoon", "bowl",
+        "banana", "apple", "sandwich", "orange", "broccoli", "carrot",
+        "hot dog", "pizza", "donut", "cake", "chair", "couch",
+        "potted plant", "bed", "dining table", "toilet", "tv", "laptop",
+        "mouse", "remote", "keyboard", "cell phone", "microwave",
+        "oven", "toaster", "sink", "refrigerator", "book", "clock",
+        "vase", "scissors", "teddy bear", "hair drier", "toothbrush" };
 
 class YoloX {
 private:
@@ -49,18 +47,15 @@ private:
     Mat grids;
 
 public:
-    YoloX(string modPath, float confThresh = 0.35, float nmsThresh = 0.5, float objThresh = 0.5, dnn::Backend bId = DNN_BACKEND_DEFAULT, dnn::Target tId = DNN_TARGET_CPU)
-        : modelPath(modPath)
-        , confThreshold(confThresh)
-        , nmsThreshold(nmsThresh)
-        , objThreshold(objThresh)
-        , backendId(bId)
-        , targetId(tId)
+    YoloX(string modPath, float confThresh = 0.35, float nmsThresh = 0.5, float objThresh = 0.5, dnn::Backend bId = DNN_BACKEND_DEFAULT, dnn::Target tId = DNN_TARGET_CPU) :
+        modelPath(modPath), confThreshold(confThresh),
+        nmsThreshold(nmsThresh), objThreshold(objThresh),
+        backendId(bId), targetId(tId)
     {
         this->num_classes = int(labelYolox.size());
         this->net = readNet(modelPath);
         this->inputSize = Size(640, 640);
-        this->strides = vector<int> { 8, 16, 32 };
+        this->strides = vector<int>{ 8, 16, 32 };
         this->net.setPreferableBackend(this->backendId);
         this->net.setPreferableTarget(this->targetId);
         this->generateAnchors();
@@ -81,7 +76,7 @@ public:
         return blob;
     }
 
-    Mat infer(Mat srcimg)
+   Mat infer(Mat srcimg)
     {
         Mat inputBlob = this->preprocess(srcimg);
 
@@ -95,7 +90,7 @@ public:
 
     Mat postprocess(Mat outputs)
     {
-        Mat dets = outputs.reshape(0, outputs.size[1]);
+        Mat dets = outputs.reshape(0,outputs.size[1]);
         Mat col01;
         add(dets.colRange(0, 2), this->grids, col01);
         Mat col23;
@@ -104,39 +99,42 @@ public:
         Mat boxes;
         hconcat(col, boxes);
         float* ptr = this->expandedStrides.ptr<float>(0);
-        for (int r = 0; r < boxes.rows; r++, ptr++) {
+        for (int r = 0; r < boxes.rows; r++, ptr++)
+        {
             boxes.rowRange(r, r + 1) = *ptr * boxes.rowRange(r, r + 1);
         }
         // get boxes
-        Mat boxes_xywh(boxes.rows, boxes.cols, CV_32FC1, Scalar(1));
+        Mat boxes_xyxy(boxes.rows, boxes.cols, CV_32FC1, Scalar(1));
         Mat scores = dets.colRange(5, dets.cols).clone();
         vector<float> maxScores(dets.rows);
         vector<int> maxScoreIdx(dets.rows);
-        vector<Rect2d> boxesXYWH(dets.rows);
+        vector<Rect2d> boxesXYXY(dets.rows);
 
-        for (int r = 0; r < boxes_xywh.rows; r++, ptr++) {
-            boxes_xywh.at<float>(r, 0) = boxes.at<float>(r, 0) - boxes.at<float>(r, 2) / 2.f;
-            boxes_xywh.at<float>(r, 1) = boxes.at<float>(r, 1) - boxes.at<float>(r, 3) / 2.f;
-            boxes_xywh.at<float>(r, 2) = boxes.at<float>(r, 2);
-            boxes_xywh.at<float>(r, 3) = boxes.at<float>(r, 3);
+        for (int r = 0; r < boxes_xyxy.rows; r++, ptr++)
+        {
+            boxes_xyxy.at<float>(r, 0) = boxes.at<float>(r, 0) - boxes.at<float>(r, 2) / 2.f;
+            boxes_xyxy.at<float>(r, 1) = boxes.at<float>(r, 1) - boxes.at<float>(r, 3) / 2.f;
+            boxes_xyxy.at<float>(r, 2) = boxes.at<float>(r, 0) + boxes.at<float>(r, 2) / 2.f;
+            boxes_xyxy.at<float>(r, 3) = boxes.at<float>(r, 1) + boxes.at<float>(r, 3) / 2.f;
             // get scores and class indices
             scores.rowRange(r, r + 1) = scores.rowRange(r, r + 1) * dets.at<float>(r, 4);
             double minVal, maxVal;
             Point maxIdx;
-            minMaxLoc(scores.rowRange(r, r + 1), &minVal, &maxVal, nullptr, &maxIdx);
+            minMaxLoc(scores.rowRange(r, r+1), &minVal, &maxVal, nullptr, &maxIdx);
             maxScoreIdx[r] = maxIdx.x;
             maxScores[r] = float(maxVal);
-            boxesXYWH[r].x = boxes_xywh.at<float>(r, 0);
-            boxesXYWH[r].y = boxes_xywh.at<float>(r, 1);
-            boxesXYWH[r].width = boxes_xywh.at<float>(r, 2);
-            boxesXYWH[r].height = boxes_xywh.at<float>(r, 3);
+            boxesXYXY[r].x = boxes_xyxy.at<float>(r, 0);
+            boxesXYXY[r].y = boxes_xyxy.at<float>(r, 1);
+            boxesXYXY[r].width = boxes_xyxy.at<float>(r, 2);
+            boxesXYXY[r].height = boxes_xyxy.at<float>(r, 3);
         }
 
         vector<int> keep;
-        NMSBoxesBatched(boxesXYWH, maxScores, maxScoreIdx, this->confThreshold, this->nmsThreshold, keep);
+        NMSBoxesBatched(boxesXYXY, maxScores, maxScoreIdx, this->confThreshold, this->nmsThreshold, keep);
         Mat candidates(int(keep.size()), 6, CV_32FC1);
         int row = 0;
-        for (auto idx : keep) {
+        for (auto idx : keep)
+        {
             boxes_xyxy.rowRange(idx, idx + 1).copyTo(candidates(Rect(0, row, 4, 1)));
             candidates.at<float>(row, 4) = maxScores[idx];
             candidates.at<float>(row, 5) = float(maxScoreIdx[idx]);
@@ -145,14 +143,17 @@ public:
         if (keep.size() == 0)
             return Mat();
         return candidates;
+        
     }
+
 
     void generateAnchors()
     {
-        vector<tuple<int, int, int>> nb;
+        vector< tuple<int, int, int> > nb;
         int total = 0;
 
-        for (auto v : this->strides) {
+        for (auto v : this->strides)
+        {
             int w = this->inputSize.width / v;
             int h = this->inputSize.height / v;
             nb.push_back(tuple<int, int, int>(w * h, w, v));
@@ -163,9 +164,11 @@ public:
         float* ptrGrids = this->grids.ptr<float>(0);
         float* ptrStrides = this->expandedStrides.ptr<float>(0);
         int pos = 0;
-        for (auto le : nb) {
+        for (auto le : nb)
+        {
             int r = get<1>(le);
-            for (int i = 0; i < get<0>(le); i++, pos++) {
+            for (int i = 0; i < get<0>(le); i++, pos++)
+            {
                 *ptrGrids++ = float(i % r);
                 *ptrGrids++ = float(i / r);
                 *ptrStrides++ = float((get<2>(le)));
@@ -174,20 +177,21 @@ public:
     }
 };
 
-std::string keys = "{ help  h          |                                               | Print help message. }"
-                   "{ model m          | object_detection_yolox_2022nov.onnx           | Usage: Path to the model, defaults to object_detection_yolox_2022nov.onnx  }"
-                   "{ input i          |                                               | Path to input image or video file. Skip this argument to capture frames from a camera.}"
-                   "{ confidence       | 0.5                                           | Class confidence }"
-                   "{ obj              | 0.5                                           | Enter object threshold }"
-                   "{ nms              | 0.5                                           | Enter nms IOU threshold }"
-                   "{ save s           | true                                          | Specify to save results. This flag is invalid when using camera. }"
-                   "{ vis v            | 1                                             | Specify to open a window for result visualization. This flag is invalid when using camera. }"
-                   "{ backend bt       | 0                                             | Choose one of computation backends: "
-                   "0: (default) OpenCV implementation + CPU, "
-                   "1: CUDA + GPU (CUDA), "
-                   "2: CUDA + GPU (CUDA FP16), "
-                   "3: TIM-VX + NPU, "
-                   "4: CANN + NPU}";
+std::string keys =
+"{ help  h          |                                               | Print help message. }"
+"{ model m          | object_detection_yolox_2022nov.onnx           | Usage: Path to the model, defaults to object_detection_yolox_2022nov.onnx  }"
+"{ input i          |                                               | Path to input image or video file. Skip this argument to capture frames from a camera.}"
+"{ confidence       | 0.5                                           | Class confidence }"
+"{ obj              | 0.5                                           | Enter object threshold }"
+"{ nms              | 0.5                                           | Enter nms IOU threshold }"
+"{ save s           | true                                          | Specify to save results. This flag is invalid when using camera. }"
+"{ vis v            | 1                                             | Specify to open a window for result visualization. This flag is invalid when using camera. }"
+"{ backend bt       | 0                                             | Choose one of computation backends: "
+"0: (default) OpenCV implementation + CPU, "
+"1: CUDA + GPU (CUDA), "
+"2: CUDA + GPU (CUDA FP16), "
+"3: TIM-VX + NPU, "
+"4: CANN + NPU}";
 
 pair<Mat, double> letterBox(Mat srcimg, Size targetSize = Size(640, 640))
 {
@@ -212,7 +216,8 @@ Mat visualize(Mat dets, Mat srcimg, double letterbox_scale, double fps = -1)
     if (fps > 0)
         putText(resImg, format("FPS: %.2f", fps), Size(10, 25), FONT_HERSHEY_SIMPLEX, 1, Scalar(0, 0, 255), 2);
 
-    for (int row = 0; row < dets.rows; row++) {
+    for (int row = 0; row < dets.rows; row++)
+    {
         Mat boxF = unLetterBox(dets(Rect(0, row, 4, 1)), letterbox_scale);
         Mat box;
         boxF.convertTo(box, CV_32S);
@@ -221,14 +226,14 @@ Mat visualize(Mat dets, Mat srcimg, double letterbox_scale, double fps = -1)
 
         int x0 = box.at<int>(0, 0);
         int y0 = box.at<int>(0, 1);
-        int w = box.at<int>(0, 2);
-        int h = box.at<int>(0, 3);
+        int x1 = box.at<int>(0, 2);
+        int y1 = box.at<int>(0, 3);
 
         string text = format("%s : %f", labelYolox[clsId].c_str(), score * 100);
         int font = FONT_HERSHEY_SIMPLEX;
         int baseLine = 0;
         Size txtSize = getTextSize(text, font, 0.4, 1, &baseLine);
-        rectangle(resImg, Rect(x0, y0, w, h), Scalar(0, 255, 0), 2);
+        rectangle(resImg, Point(x0, y0), Point(x1, y1), Scalar(0, 255, 0), 2);
         rectangle(resImg, Point(x0, y0 + 1), Point(x0 + txtSize.width + 1, y0 + int(1.5 * txtSize.height)), Scalar(255, 255, 255), -1);
         putText(resImg, text, Point(x0, y0 + txtSize.height), font, 0.4, Scalar(0, 0, 0), 1);
     }
@@ -241,7 +246,8 @@ int main(int argc, char** argv)
     CommandLineParser parser(argc, argv, keys);
 
     parser.about("Use this script to run Yolox deep learning networks in opencv_zoo using OpenCV.");
-    if (parser.has("help")) {
+    if (parser.has("help"))
+    {
         parser.printMessage();
         return 0;
     }
@@ -254,7 +260,8 @@ int main(int argc, char** argv)
     bool save = parser.get<bool>("save");
     int backendTargetid = parser.get<int>("backend");
 
-    if (model.empty()) {
+    if (model.empty())
+    {
         CV_Error(Error::StsError, "Model file " + model + " not found");
     }
 
@@ -273,26 +280,30 @@ int main(int argc, char** argv)
 
     static const std::string kWinName = model;
     int nbInference = 0;
-    while (waitKey(1) < 0) {
+    while (waitKey(1) < 0)
+    {
         cap >> frame;
-        if (frame.empty()) {
+        if (frame.empty())
+        {
             cout << "Frame is empty" << endl;
             waitKey();
             break;
         }
         pair<Mat, double> w = letterBox(frame);
         inputBlob = get<0>(w);
-        letterboxScale = get<1>(w);
+        letterboxScale  = get<1>(w);
         TickMeter tm;
         tm.start();
         Mat predictions = modelNet.infer(inputBlob);
         tm.stop();
         cout << "Inference time: " << tm.getTimeMilli() << " ms\n";
         Mat img = visualize(predictions, frame, letterboxScale, tm.getFPS());
-        if (save && parser.has("input")) {
+        if (save && parser.has("input"))
+        {
             imwrite("result.jpg", img);
         }
-        if (vis) {
+        if (vis)
+        {
             imshow(kWinName, img);
         }
     }

--- a/models/object_detection_yolox/demo.cpp
+++ b/models/object_detection_yolox/demo.cpp
@@ -1,6 +1,6 @@
-#include <vector>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <opencv2/opencv.hpp>
 
@@ -8,28 +8,30 @@ using namespace std;
 using namespace cv;
 using namespace dnn;
 
-vector< pair<dnn::Backend, dnn::Target> > backendTargetPairs = {
-        std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_OPENCV, dnn::DNN_TARGET_CPU),
-        std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CUDA, dnn::DNN_TARGET_CUDA),
-        std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CUDA, dnn::DNN_TARGET_CUDA_FP16),
-        std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_TIMVX, dnn::DNN_TARGET_NPU),
-        std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CANN, dnn::DNN_TARGET_NPU) };
+vector<pair<dnn::Backend, dnn::Target>> backendTargetPairs = {
+    std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_OPENCV, dnn::DNN_TARGET_CPU),
+    std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CUDA, dnn::DNN_TARGET_CUDA),
+    std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CUDA, dnn::DNN_TARGET_CUDA_FP16),
+    std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_TIMVX, dnn::DNN_TARGET_NPU),
+    std::make_pair<dnn::Backend, dnn::Target>(dnn::DNN_BACKEND_CANN, dnn::DNN_TARGET_NPU)
+};
 
 vector<string> labelYolox = {
-        "person", "bicycle", "car", "motorcycle", "airplane", "bus",
-        "train", "truck", "boat", "traffic light", "fire hydrant",
-        "stop sign", "parking meter", "bench", "bird", "cat", "dog",
-        "horse", "sheep", "cow", "elephant", "bear", "zebra", "giraffe",
-        "backpack", "umbrella", "handbag", "tie", "suitcase", "frisbee",
-        "skis", "snowboard", "sports ball", "kite", "baseball bat",
-        "baseball glove", "skateboard", "surfboard", "tennis racket",
-        "bottle", "wine glass", "cup", "fork", "knife", "spoon", "bowl",
-        "banana", "apple", "sandwich", "orange", "broccoli", "carrot",
-        "hot dog", "pizza", "donut", "cake", "chair", "couch",
-        "potted plant", "bed", "dining table", "toilet", "tv", "laptop",
-        "mouse", "remote", "keyboard", "cell phone", "microwave",
-        "oven", "toaster", "sink", "refrigerator", "book", "clock",
-        "vase", "scissors", "teddy bear", "hair drier", "toothbrush" };
+    "person", "bicycle", "car", "motorcycle", "airplane", "bus",
+    "train", "truck", "boat", "traffic light", "fire hydrant",
+    "stop sign", "parking meter", "bench", "bird", "cat", "dog",
+    "horse", "sheep", "cow", "elephant", "bear", "zebra", "giraffe",
+    "backpack", "umbrella", "handbag", "tie", "suitcase", "frisbee",
+    "skis", "snowboard", "sports ball", "kite", "baseball bat",
+    "baseball glove", "skateboard", "surfboard", "tennis racket",
+    "bottle", "wine glass", "cup", "fork", "knife", "spoon", "bowl",
+    "banana", "apple", "sandwich", "orange", "broccoli", "carrot",
+    "hot dog", "pizza", "donut", "cake", "chair", "couch",
+    "potted plant", "bed", "dining table", "toilet", "tv", "laptop",
+    "mouse", "remote", "keyboard", "cell phone", "microwave",
+    "oven", "toaster", "sink", "refrigerator", "book", "clock",
+    "vase", "scissors", "teddy bear", "hair drier", "toothbrush"
+};
 
 class YoloX {
 private:
@@ -47,15 +49,18 @@ private:
     Mat grids;
 
 public:
-    YoloX(string modPath, float confThresh = 0.35, float nmsThresh = 0.5, float objThresh = 0.5, dnn::Backend bId = DNN_BACKEND_DEFAULT, dnn::Target tId = DNN_TARGET_CPU) :
-        modelPath(modPath), confThreshold(confThresh),
-        nmsThreshold(nmsThresh), objThreshold(objThresh),
-        backendId(bId), targetId(tId)
+    YoloX(string modPath, float confThresh = 0.35, float nmsThresh = 0.5, float objThresh = 0.5, dnn::Backend bId = DNN_BACKEND_DEFAULT, dnn::Target tId = DNN_TARGET_CPU)
+        : modelPath(modPath)
+        , confThreshold(confThresh)
+        , nmsThreshold(nmsThresh)
+        , objThreshold(objThresh)
+        , backendId(bId)
+        , targetId(tId)
     {
         this->num_classes = int(labelYolox.size());
         this->net = readNet(modelPath);
         this->inputSize = Size(640, 640);
-        this->strides = vector<int>{ 8, 16, 32 };
+        this->strides = vector<int> { 8, 16, 32 };
         this->net.setPreferableBackend(this->backendId);
         this->net.setPreferableTarget(this->targetId);
         this->generateAnchors();
@@ -76,7 +81,7 @@ public:
         return blob;
     }
 
-   Mat infer(Mat srcimg)
+    Mat infer(Mat srcimg)
     {
         Mat inputBlob = this->preprocess(srcimg);
 
@@ -90,7 +95,7 @@ public:
 
     Mat postprocess(Mat outputs)
     {
-        Mat dets = outputs.reshape(0,outputs.size[1]);
+        Mat dets = outputs.reshape(0, outputs.size[1]);
         Mat col01;
         add(dets.colRange(0, 2), this->grids, col01);
         Mat col23;
@@ -99,42 +104,39 @@ public:
         Mat boxes;
         hconcat(col, boxes);
         float* ptr = this->expandedStrides.ptr<float>(0);
-        for (int r = 0; r < boxes.rows; r++, ptr++)
-        {
+        for (int r = 0; r < boxes.rows; r++, ptr++) {
             boxes.rowRange(r, r + 1) = *ptr * boxes.rowRange(r, r + 1);
         }
         // get boxes
-        Mat boxes_xyxy(boxes.rows, boxes.cols, CV_32FC1, Scalar(1));
+        Mat boxes_xywh(boxes.rows, boxes.cols, CV_32FC1, Scalar(1));
         Mat scores = dets.colRange(5, dets.cols).clone();
         vector<float> maxScores(dets.rows);
         vector<int> maxScoreIdx(dets.rows);
-        vector<Rect2d> boxesXYXY(dets.rows);
+        vector<Rect2d> boxesXYWH(dets.rows);
 
-        for (int r = 0; r < boxes_xyxy.rows; r++, ptr++)
-        {
-            boxes_xyxy.at<float>(r, 0) = boxes.at<float>(r, 0) - boxes.at<float>(r, 2) / 2.f;
-            boxes_xyxy.at<float>(r, 1) = boxes.at<float>(r, 1) - boxes.at<float>(r, 3) / 2.f;
-            boxes_xyxy.at<float>(r, 2) = boxes.at<float>(r, 0) + boxes.at<float>(r, 2) / 2.f;
-            boxes_xyxy.at<float>(r, 3) = boxes.at<float>(r, 1) + boxes.at<float>(r, 3) / 2.f;
+        for (int r = 0; r < boxes_xywh.rows; r++, ptr++) {
+            boxes_xywh.at<float>(r, 0) = boxes.at<float>(r, 0) - boxes.at<float>(r, 2) / 2.f;
+            boxes_xywh.at<float>(r, 1) = boxes.at<float>(r, 1) - boxes.at<float>(r, 3) / 2.f;
+            boxes_xywh.at<float>(r, 2) = boxes.at<float>(r, 2);
+            boxes_xywh.at<float>(r, 3) = boxes.at<float>(r, 3);
             // get scores and class indices
             scores.rowRange(r, r + 1) = scores.rowRange(r, r + 1) * dets.at<float>(r, 4);
             double minVal, maxVal;
             Point maxIdx;
-            minMaxLoc(scores.rowRange(r, r+1), &minVal, &maxVal, nullptr, &maxIdx);
+            minMaxLoc(scores.rowRange(r, r + 1), &minVal, &maxVal, nullptr, &maxIdx);
             maxScoreIdx[r] = maxIdx.x;
             maxScores[r] = float(maxVal);
-            boxesXYXY[r].x = boxes_xyxy.at<float>(r, 0);
-            boxesXYXY[r].y = boxes_xyxy.at<float>(r, 1);
-            boxesXYXY[r].width = boxes_xyxy.at<float>(r, 2);
-            boxesXYXY[r].height = boxes_xyxy.at<float>(r, 3);
+            boxesXYWH[r].x = boxes_xywh.at<float>(r, 0);
+            boxesXYWH[r].y = boxes_xywh.at<float>(r, 1);
+            boxesXYWH[r].width = boxes_xywh.at<float>(r, 2);
+            boxesXYWH[r].height = boxes_xywh.at<float>(r, 3);
         }
 
         vector<int> keep;
-        NMSBoxesBatched(boxesXYXY, maxScores, maxScoreIdx, this->confThreshold, this->nmsThreshold, keep);
+        NMSBoxesBatched(boxesXYWH, maxScores, maxScoreIdx, this->confThreshold, this->nmsThreshold, keep);
         Mat candidates(int(keep.size()), 6, CV_32FC1);
         int row = 0;
-        for (auto idx : keep)
-        {
+        for (auto idx : keep) {
             boxes_xyxy.rowRange(idx, idx + 1).copyTo(candidates(Rect(0, row, 4, 1)));
             candidates.at<float>(row, 4) = maxScores[idx];
             candidates.at<float>(row, 5) = float(maxScoreIdx[idx]);
@@ -143,17 +145,14 @@ public:
         if (keep.size() == 0)
             return Mat();
         return candidates;
-        
     }
-
 
     void generateAnchors()
     {
-        vector< tuple<int, int, int> > nb;
+        vector<tuple<int, int, int>> nb;
         int total = 0;
 
-        for (auto v : this->strides)
-        {
+        for (auto v : this->strides) {
             int w = this->inputSize.width / v;
             int h = this->inputSize.height / v;
             nb.push_back(tuple<int, int, int>(w * h, w, v));
@@ -164,11 +163,9 @@ public:
         float* ptrGrids = this->grids.ptr<float>(0);
         float* ptrStrides = this->expandedStrides.ptr<float>(0);
         int pos = 0;
-        for (auto le : nb)
-        {
+        for (auto le : nb) {
             int r = get<1>(le);
-            for (int i = 0; i < get<0>(le); i++, pos++)
-            {
+            for (int i = 0; i < get<0>(le); i++, pos++) {
                 *ptrGrids++ = float(i % r);
                 *ptrGrids++ = float(i / r);
                 *ptrStrides++ = float((get<2>(le)));
@@ -177,21 +174,20 @@ public:
     }
 };
 
-std::string keys =
-"{ help  h          |                                               | Print help message. }"
-"{ model m          | object_detection_yolox_2022nov.onnx           | Usage: Path to the model, defaults to object_detection_yolox_2022nov.onnx  }"
-"{ input i          |                                               | Path to input image or video file. Skip this argument to capture frames from a camera.}"
-"{ confidence       | 0.5                                           | Class confidence }"
-"{ obj              | 0.5                                           | Enter object threshold }"
-"{ nms              | 0.5                                           | Enter nms IOU threshold }"
-"{ save s           | true                                          | Specify to save results. This flag is invalid when using camera. }"
-"{ vis v            | 1                                             | Specify to open a window for result visualization. This flag is invalid when using camera. }"
-"{ backend bt       | 0                                             | Choose one of computation backends: "
-"0: (default) OpenCV implementation + CPU, "
-"1: CUDA + GPU (CUDA), "
-"2: CUDA + GPU (CUDA FP16), "
-"3: TIM-VX + NPU, "
-"4: CANN + NPU}";
+std::string keys = "{ help  h          |                                               | Print help message. }"
+                   "{ model m          | object_detection_yolox_2022nov.onnx           | Usage: Path to the model, defaults to object_detection_yolox_2022nov.onnx  }"
+                   "{ input i          |                                               | Path to input image or video file. Skip this argument to capture frames from a camera.}"
+                   "{ confidence       | 0.5                                           | Class confidence }"
+                   "{ obj              | 0.5                                           | Enter object threshold }"
+                   "{ nms              | 0.5                                           | Enter nms IOU threshold }"
+                   "{ save s           | true                                          | Specify to save results. This flag is invalid when using camera. }"
+                   "{ vis v            | 1                                             | Specify to open a window for result visualization. This flag is invalid when using camera. }"
+                   "{ backend bt       | 0                                             | Choose one of computation backends: "
+                   "0: (default) OpenCV implementation + CPU, "
+                   "1: CUDA + GPU (CUDA), "
+                   "2: CUDA + GPU (CUDA FP16), "
+                   "3: TIM-VX + NPU, "
+                   "4: CANN + NPU}";
 
 pair<Mat, double> letterBox(Mat srcimg, Size targetSize = Size(640, 640))
 {
@@ -216,8 +212,7 @@ Mat visualize(Mat dets, Mat srcimg, double letterbox_scale, double fps = -1)
     if (fps > 0)
         putText(resImg, format("FPS: %.2f", fps), Size(10, 25), FONT_HERSHEY_SIMPLEX, 1, Scalar(0, 0, 255), 2);
 
-    for (int row = 0; row < dets.rows; row++)
-    {
+    for (int row = 0; row < dets.rows; row++) {
         Mat boxF = unLetterBox(dets(Rect(0, row, 4, 1)), letterbox_scale);
         Mat box;
         boxF.convertTo(box, CV_32S);
@@ -226,14 +221,14 @@ Mat visualize(Mat dets, Mat srcimg, double letterbox_scale, double fps = -1)
 
         int x0 = box.at<int>(0, 0);
         int y0 = box.at<int>(0, 1);
-        int x1 = box.at<int>(0, 2);
-        int y1 = box.at<int>(0, 3);
+        int w = box.at<int>(0, 2);
+        int h = box.at<int>(0, 3);
 
         string text = format("%s : %f", labelYolox[clsId].c_str(), score * 100);
         int font = FONT_HERSHEY_SIMPLEX;
         int baseLine = 0;
         Size txtSize = getTextSize(text, font, 0.4, 1, &baseLine);
-        rectangle(resImg, Point(x0, y0), Point(x1, y1), Scalar(0, 255, 0), 2);
+        rectangle(resImg, Rect(x0, y0, w, h), Scalar(0, 255, 0), 2);
         rectangle(resImg, Point(x0, y0 + 1), Point(x0 + txtSize.width + 1, y0 + int(1.5 * txtSize.height)), Scalar(255, 255, 255), -1);
         putText(resImg, text, Point(x0, y0 + txtSize.height), font, 0.4, Scalar(0, 0, 0), 1);
     }
@@ -246,8 +241,7 @@ int main(int argc, char** argv)
     CommandLineParser parser(argc, argv, keys);
 
     parser.about("Use this script to run Yolox deep learning networks in opencv_zoo using OpenCV.");
-    if (parser.has("help"))
-    {
+    if (parser.has("help")) {
         parser.printMessage();
         return 0;
     }
@@ -260,8 +254,7 @@ int main(int argc, char** argv)
     bool save = parser.get<bool>("save");
     int backendTargetid = parser.get<int>("backend");
 
-    if (model.empty())
-    {
+    if (model.empty()) {
         CV_Error(Error::StsError, "Model file " + model + " not found");
     }
 
@@ -280,30 +273,26 @@ int main(int argc, char** argv)
 
     static const std::string kWinName = model;
     int nbInference = 0;
-    while (waitKey(1) < 0)
-    {
+    while (waitKey(1) < 0) {
         cap >> frame;
-        if (frame.empty())
-        {
+        if (frame.empty()) {
             cout << "Frame is empty" << endl;
             waitKey();
             break;
         }
         pair<Mat, double> w = letterBox(frame);
         inputBlob = get<0>(w);
-        letterboxScale  = get<1>(w);
+        letterboxScale = get<1>(w);
         TickMeter tm;
         tm.start();
         Mat predictions = modelNet.infer(inputBlob);
         tm.stop();
         cout << "Inference time: " << tm.getTimeMilli() << " ms\n";
         Mat img = visualize(predictions, frame, letterboxScale, tm.getFPS());
-        if (save && parser.has("input"))
-        {
+        if (save && parser.has("input")) {
             imwrite("result.jpg", img);
         }
-        if (vis)
-        {
+        if (vis) {
             imshow(kWinName, img);
         }
     }

--- a/models/object_detection_yolox/demo.py
+++ b/models/object_detection_yolox/demo.py
@@ -4,106 +4,222 @@ import argparse
 
 # Check OpenCV version
 opencv_python_version = lambda str_version: tuple(map(int, (str_version.split("."))))
-assert opencv_python_version(cv.__version__) >= opencv_python_version("4.10.0"), \
-       "Please install latest opencv-python for benchmark: python3 -m pip install --upgrade opencv-python"
+assert opencv_python_version(cv.__version__) >= opencv_python_version(
+    "4.10.0"
+), "Please install latest opencv-python for benchmark: python3 -m pip install --upgrade opencv-python"
 
 from yolox import YoloX
 
 # Valid combinations of backends and targets
 backend_target_pairs = [
     [cv.dnn.DNN_BACKEND_OPENCV, cv.dnn.DNN_TARGET_CPU],
-    [cv.dnn.DNN_BACKEND_CUDA,   cv.dnn.DNN_TARGET_CUDA],
-    [cv.dnn.DNN_BACKEND_CUDA,   cv.dnn.DNN_TARGET_CUDA_FP16],
-    [cv.dnn.DNN_BACKEND_TIMVX,  cv.dnn.DNN_TARGET_NPU],
-    [cv.dnn.DNN_BACKEND_CANN,   cv.dnn.DNN_TARGET_NPU]
+    [cv.dnn.DNN_BACKEND_CUDA, cv.dnn.DNN_TARGET_CUDA],
+    [cv.dnn.DNN_BACKEND_CUDA, cv.dnn.DNN_TARGET_CUDA_FP16],
+    [cv.dnn.DNN_BACKEND_TIMVX, cv.dnn.DNN_TARGET_NPU],
+    [cv.dnn.DNN_BACKEND_CANN, cv.dnn.DNN_TARGET_NPU],
 ]
 
-classes = ('person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus',
-           'train', 'truck', 'boat', 'traffic light', 'fire hydrant',
-           'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog',
-           'horse', 'sheep', 'cow', 'elephant', 'bear', 'zebra', 'giraffe',
-           'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
-           'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat',
-           'baseball glove', 'skateboard', 'surfboard', 'tennis racket',
-           'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl',
-           'banana', 'apple', 'sandwich', 'orange', 'broccoli', 'carrot',
-           'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
-           'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop',
-           'mouse', 'remote', 'keyboard', 'cell phone', 'microwave',
-           'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock',
-           'vase', 'scissors', 'teddy bear', 'hair drier', 'toothbrush')
+classes = (
+    "person",
+    "bicycle",
+    "car",
+    "motorcycle",
+    "airplane",
+    "bus",
+    "train",
+    "truck",
+    "boat",
+    "traffic light",
+    "fire hydrant",
+    "stop sign",
+    "parking meter",
+    "bench",
+    "bird",
+    "cat",
+    "dog",
+    "horse",
+    "sheep",
+    "cow",
+    "elephant",
+    "bear",
+    "zebra",
+    "giraffe",
+    "backpack",
+    "umbrella",
+    "handbag",
+    "tie",
+    "suitcase",
+    "frisbee",
+    "skis",
+    "snowboard",
+    "sports ball",
+    "kite",
+    "baseball bat",
+    "baseball glove",
+    "skateboard",
+    "surfboard",
+    "tennis racket",
+    "bottle",
+    "wine glass",
+    "cup",
+    "fork",
+    "knife",
+    "spoon",
+    "bowl",
+    "banana",
+    "apple",
+    "sandwich",
+    "orange",
+    "broccoli",
+    "carrot",
+    "hot dog",
+    "pizza",
+    "donut",
+    "cake",
+    "chair",
+    "couch",
+    "potted plant",
+    "bed",
+    "dining table",
+    "toilet",
+    "tv",
+    "laptop",
+    "mouse",
+    "remote",
+    "keyboard",
+    "cell phone",
+    "microwave",
+    "oven",
+    "toaster",
+    "sink",
+    "refrigerator",
+    "book",
+    "clock",
+    "vase",
+    "scissors",
+    "teddy bear",
+    "hair drier",
+    "toothbrush",
+)
+
 
 def letterbox(srcimg, target_size=(640, 640)):
     padded_img = np.ones((target_size[0], target_size[1], 3)).astype(np.float32) * 114.0
     ratio = min(target_size[0] / srcimg.shape[0], target_size[1] / srcimg.shape[1])
     resized_img = cv.resize(
-        srcimg, (int(srcimg.shape[1] * ratio), int(srcimg.shape[0] * ratio)), interpolation=cv.INTER_LINEAR
+        srcimg,
+        (int(srcimg.shape[1] * ratio), int(srcimg.shape[0] * ratio)),
+        interpolation=cv.INTER_LINEAR,
     ).astype(np.float32)
-    padded_img[: int(srcimg.shape[0] * ratio), : int(srcimg.shape[1] * ratio)] = resized_img
+    padded_img[: int(srcimg.shape[0] * ratio), : int(srcimg.shape[1] * ratio)] = (
+        resized_img
+    )
 
     return padded_img, ratio
 
+
 def unletterbox(bbox, letterbox_scale):
     return bbox / letterbox_scale
+
 
 def vis(dets, srcimg, letterbox_scale, fps=None):
     res_img = srcimg.copy()
 
     if fps is not None:
         fps_label = "FPS: %.2f" % fps
-        cv.putText(res_img, fps_label, (10, 25), cv.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 255), 2)
+        cv.putText(
+            res_img, fps_label, (10, 25), cv.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 255), 2
+        )
 
     for det in dets:
         box = unletterbox(det[:4], letterbox_scale).astype(np.int32)
         score = det[-2]
         cls_id = int(det[-1])
 
-        x0, y0, x1, y1 = box
+        x0, y0, w, h = box
 
-        text = '{}:{:.1f}%'.format(classes[cls_id], score * 100)
+        text = "{}:{:.1f}%".format(classes[cls_id], score * 100)
         font = cv.FONT_HERSHEY_SIMPLEX
         txt_size = cv.getTextSize(text, font, 0.4, 1)[0]
-        cv.rectangle(res_img, (x0, y0), (x1, y1), (0, 255, 0), 2)
-        cv.rectangle(res_img, (x0, y0 + 1), (x0 + txt_size[0] + 1, y0 + int(1.5 * txt_size[1])), (255, 255, 255), -1)
-        cv.putText(res_img, text, (x0, y0 + txt_size[1]), font, 0.4, (0, 0, 0), thickness=1)
+        cv.rectangle(res_img, (x0, y0, w, h), (0, 255, 0), 2)
+        cv.rectangle(
+            res_img,
+            (x0, y0 + 1),
+            (x0 + txt_size[0] + 1, y0 + int(1.5 * txt_size[1])),
+            (255, 255, 255),
+            -1,
+        )
+        cv.putText(
+            res_img, text, (x0, y0 + txt_size[1]), font, 0.4, (0, 0, 0), thickness=1
+        )
 
     return res_img
 
-if __name__=='__main__':
-    parser = argparse.ArgumentParser(description='Nanodet inference using OpenCV an contribution by Sri Siddarth Chakaravarthy part of GSOC_2022')
-    parser.add_argument('--input', '-i', type=str,
-                        help='Path to the input image. Omit for using default camera.')
-    parser.add_argument('--model', '-m', type=str, default='object_detection_yolox_2022nov.onnx',
-                        help="Path to the model")
-    parser.add_argument('--backend_target', '-bt', type=int, default=0,
-                    help='''Choose one of the backend-target pair to run this demo:
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Nanodet inference using OpenCV an contribution by Sri Siddarth Chakaravarthy part of GSOC_2022"
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        type=str,
+        help="Path to the input image. Omit for using default camera.",
+    )
+    parser.add_argument(
+        "--model",
+        "-m",
+        type=str,
+        default="object_detection_yolox_2022nov.onnx",
+        help="Path to the model",
+    )
+    parser.add_argument(
+        "--backend_target",
+        "-bt",
+        type=int,
+        default=0,
+        help="""Choose one of the backend-target pair to run this demo:
                         {:d}: (default) OpenCV implementation + CPU,
                         {:d}: CUDA + GPU (CUDA),
                         {:d}: CUDA + GPU (CUDA FP16),
                         {:d}: TIM-VX + NPU,
                         {:d}: CANN + NPU
-                    '''.format(*[x for x in range(len(backend_target_pairs))]))
-    parser.add_argument('--confidence', default=0.5, type=float,
-                        help='Class confidence')
-    parser.add_argument('--nms', default=0.5, type=float,
-                        help='Enter nms IOU threshold')
-    parser.add_argument('--obj', default=0.5, type=float,
-                        help='Enter object threshold')
-    parser.add_argument('--save', '-s', action='store_true',
-                        help='Specify to save results. This flag is invalid when using camera.')
-    parser.add_argument('--vis', '-v', action='store_true',
-                        help='Specify to open a window for result visualization. This flag is invalid when using camera.')
+                    """.format(
+            *[x for x in range(len(backend_target_pairs))]
+        ),
+    )
+    parser.add_argument(
+        "--confidence", default=0.5, type=float, help="Class confidence"
+    )
+    parser.add_argument(
+        "--nms", default=0.5, type=float, help="Enter nms IOU threshold"
+    )
+    parser.add_argument("--obj", default=0.5, type=float, help="Enter object threshold")
+    parser.add_argument(
+        "--save",
+        "-s",
+        action="store_true",
+        help="Specify to save results. This flag is invalid when using camera.",
+    )
+    parser.add_argument(
+        "--vis",
+        "-v",
+        action="store_true",
+        help="Specify to open a window for result visualization. This flag is invalid when using camera.",
+    )
     args = parser.parse_args()
 
     backend_id = backend_target_pairs[args.backend_target][0]
     target_id = backend_target_pairs[args.backend_target][1]
 
-    model_net = YoloX(modelPath= args.model,
-                      confThreshold=args.confidence,
-                      nmsThreshold=args.nms,
-                      objThreshold=args.obj,
-                      backendId=backend_id,
-                      targetId=target_id)
+    model_net = YoloX(
+        modelPath=args.model,
+        confThreshold=args.confidence,
+        nmsThreshold=args.nms,
+        objThreshold=args.obj,
+        backendId=backend_id,
+        targetId=target_id,
+    )
 
     tm = cv.TickMeter()
     tm.reset()
@@ -121,8 +237,8 @@ if __name__=='__main__':
         img = vis(preds, image, letterbox_scale)
 
         if args.save:
-            print('Results saved to result.jpg\n')
-            cv.imwrite('result.jpg', img)
+            print("Results saved to result.jpg\n")
+            cv.imwrite("result.jpg", img)
 
         if args.vis:
             cv.namedWindow(args.input, cv.WINDOW_AUTOSIZE)
@@ -137,7 +253,7 @@ if __name__=='__main__':
         while cv.waitKey(1) < 0:
             hasFrame, frame = cap.read()
             if not hasFrame:
-                print('No frames grabbed!')
+                print("No frames grabbed!")
                 break
 
             input_blob = cv.cvtColor(frame, cv.COLOR_BGR2RGB)

--- a/models/object_detection_yolox/demo.py
+++ b/models/object_detection_yolox/demo.py
@@ -4,222 +4,106 @@ import argparse
 
 # Check OpenCV version
 opencv_python_version = lambda str_version: tuple(map(int, (str_version.split("."))))
-assert opencv_python_version(cv.__version__) >= opencv_python_version(
-    "4.10.0"
-), "Please install latest opencv-python for benchmark: python3 -m pip install --upgrade opencv-python"
+assert opencv_python_version(cv.__version__) >= opencv_python_version("4.10.0"), \
+       "Please install latest opencv-python for benchmark: python3 -m pip install --upgrade opencv-python"
 
 from yolox import YoloX
 
 # Valid combinations of backends and targets
 backend_target_pairs = [
     [cv.dnn.DNN_BACKEND_OPENCV, cv.dnn.DNN_TARGET_CPU],
-    [cv.dnn.DNN_BACKEND_CUDA, cv.dnn.DNN_TARGET_CUDA],
-    [cv.dnn.DNN_BACKEND_CUDA, cv.dnn.DNN_TARGET_CUDA_FP16],
-    [cv.dnn.DNN_BACKEND_TIMVX, cv.dnn.DNN_TARGET_NPU],
-    [cv.dnn.DNN_BACKEND_CANN, cv.dnn.DNN_TARGET_NPU],
+    [cv.dnn.DNN_BACKEND_CUDA,   cv.dnn.DNN_TARGET_CUDA],
+    [cv.dnn.DNN_BACKEND_CUDA,   cv.dnn.DNN_TARGET_CUDA_FP16],
+    [cv.dnn.DNN_BACKEND_TIMVX,  cv.dnn.DNN_TARGET_NPU],
+    [cv.dnn.DNN_BACKEND_CANN,   cv.dnn.DNN_TARGET_NPU]
 ]
 
-classes = (
-    "person",
-    "bicycle",
-    "car",
-    "motorcycle",
-    "airplane",
-    "bus",
-    "train",
-    "truck",
-    "boat",
-    "traffic light",
-    "fire hydrant",
-    "stop sign",
-    "parking meter",
-    "bench",
-    "bird",
-    "cat",
-    "dog",
-    "horse",
-    "sheep",
-    "cow",
-    "elephant",
-    "bear",
-    "zebra",
-    "giraffe",
-    "backpack",
-    "umbrella",
-    "handbag",
-    "tie",
-    "suitcase",
-    "frisbee",
-    "skis",
-    "snowboard",
-    "sports ball",
-    "kite",
-    "baseball bat",
-    "baseball glove",
-    "skateboard",
-    "surfboard",
-    "tennis racket",
-    "bottle",
-    "wine glass",
-    "cup",
-    "fork",
-    "knife",
-    "spoon",
-    "bowl",
-    "banana",
-    "apple",
-    "sandwich",
-    "orange",
-    "broccoli",
-    "carrot",
-    "hot dog",
-    "pizza",
-    "donut",
-    "cake",
-    "chair",
-    "couch",
-    "potted plant",
-    "bed",
-    "dining table",
-    "toilet",
-    "tv",
-    "laptop",
-    "mouse",
-    "remote",
-    "keyboard",
-    "cell phone",
-    "microwave",
-    "oven",
-    "toaster",
-    "sink",
-    "refrigerator",
-    "book",
-    "clock",
-    "vase",
-    "scissors",
-    "teddy bear",
-    "hair drier",
-    "toothbrush",
-)
-
+classes = ('person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus',
+           'train', 'truck', 'boat', 'traffic light', 'fire hydrant',
+           'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog',
+           'horse', 'sheep', 'cow', 'elephant', 'bear', 'zebra', 'giraffe',
+           'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
+           'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat',
+           'baseball glove', 'skateboard', 'surfboard', 'tennis racket',
+           'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl',
+           'banana', 'apple', 'sandwich', 'orange', 'broccoli', 'carrot',
+           'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
+           'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop',
+           'mouse', 'remote', 'keyboard', 'cell phone', 'microwave',
+           'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock',
+           'vase', 'scissors', 'teddy bear', 'hair drier', 'toothbrush')
 
 def letterbox(srcimg, target_size=(640, 640)):
     padded_img = np.ones((target_size[0], target_size[1], 3)).astype(np.float32) * 114.0
     ratio = min(target_size[0] / srcimg.shape[0], target_size[1] / srcimg.shape[1])
     resized_img = cv.resize(
-        srcimg,
-        (int(srcimg.shape[1] * ratio), int(srcimg.shape[0] * ratio)),
-        interpolation=cv.INTER_LINEAR,
+        srcimg, (int(srcimg.shape[1] * ratio), int(srcimg.shape[0] * ratio)), interpolation=cv.INTER_LINEAR
     ).astype(np.float32)
-    padded_img[: int(srcimg.shape[0] * ratio), : int(srcimg.shape[1] * ratio)] = (
-        resized_img
-    )
+    padded_img[: int(srcimg.shape[0] * ratio), : int(srcimg.shape[1] * ratio)] = resized_img
 
     return padded_img, ratio
 
-
 def unletterbox(bbox, letterbox_scale):
     return bbox / letterbox_scale
-
 
 def vis(dets, srcimg, letterbox_scale, fps=None):
     res_img = srcimg.copy()
 
     if fps is not None:
         fps_label = "FPS: %.2f" % fps
-        cv.putText(
-            res_img, fps_label, (10, 25), cv.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 255), 2
-        )
+        cv.putText(res_img, fps_label, (10, 25), cv.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 255), 2)
 
     for det in dets:
         box = unletterbox(det[:4], letterbox_scale).astype(np.int32)
         score = det[-2]
         cls_id = int(det[-1])
 
-        x0, y0, w, h = box
+        x0, y0, x1, y1 = box
 
-        text = "{}:{:.1f}%".format(classes[cls_id], score * 100)
+        text = '{}:{:.1f}%'.format(classes[cls_id], score * 100)
         font = cv.FONT_HERSHEY_SIMPLEX
         txt_size = cv.getTextSize(text, font, 0.4, 1)[0]
-        cv.rectangle(res_img, (x0, y0, w, h), (0, 255, 0), 2)
-        cv.rectangle(
-            res_img,
-            (x0, y0 + 1),
-            (x0 + txt_size[0] + 1, y0 + int(1.5 * txt_size[1])),
-            (255, 255, 255),
-            -1,
-        )
-        cv.putText(
-            res_img, text, (x0, y0 + txt_size[1]), font, 0.4, (0, 0, 0), thickness=1
-        )
+        cv.rectangle(res_img, (x0, y0), (x1, y1), (0, 255, 0), 2)
+        cv.rectangle(res_img, (x0, y0 + 1), (x0 + txt_size[0] + 1, y0 + int(1.5 * txt_size[1])), (255, 255, 255), -1)
+        cv.putText(res_img, text, (x0, y0 + txt_size[1]), font, 0.4, (0, 0, 0), thickness=1)
 
     return res_img
 
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Nanodet inference using OpenCV an contribution by Sri Siddarth Chakaravarthy part of GSOC_2022"
-    )
-    parser.add_argument(
-        "--input",
-        "-i",
-        type=str,
-        help="Path to the input image. Omit for using default camera.",
-    )
-    parser.add_argument(
-        "--model",
-        "-m",
-        type=str,
-        default="object_detection_yolox_2022nov.onnx",
-        help="Path to the model",
-    )
-    parser.add_argument(
-        "--backend_target",
-        "-bt",
-        type=int,
-        default=0,
-        help="""Choose one of the backend-target pair to run this demo:
+if __name__=='__main__':
+    parser = argparse.ArgumentParser(description='Nanodet inference using OpenCV an contribution by Sri Siddarth Chakaravarthy part of GSOC_2022')
+    parser.add_argument('--input', '-i', type=str,
+                        help='Path to the input image. Omit for using default camera.')
+    parser.add_argument('--model', '-m', type=str, default='object_detection_yolox_2022nov.onnx',
+                        help="Path to the model")
+    parser.add_argument('--backend_target', '-bt', type=int, default=0,
+                    help='''Choose one of the backend-target pair to run this demo:
                         {:d}: (default) OpenCV implementation + CPU,
                         {:d}: CUDA + GPU (CUDA),
                         {:d}: CUDA + GPU (CUDA FP16),
                         {:d}: TIM-VX + NPU,
                         {:d}: CANN + NPU
-                    """.format(
-            *[x for x in range(len(backend_target_pairs))]
-        ),
-    )
-    parser.add_argument(
-        "--confidence", default=0.5, type=float, help="Class confidence"
-    )
-    parser.add_argument(
-        "--nms", default=0.5, type=float, help="Enter nms IOU threshold"
-    )
-    parser.add_argument("--obj", default=0.5, type=float, help="Enter object threshold")
-    parser.add_argument(
-        "--save",
-        "-s",
-        action="store_true",
-        help="Specify to save results. This flag is invalid when using camera.",
-    )
-    parser.add_argument(
-        "--vis",
-        "-v",
-        action="store_true",
-        help="Specify to open a window for result visualization. This flag is invalid when using camera.",
-    )
+                    '''.format(*[x for x in range(len(backend_target_pairs))]))
+    parser.add_argument('--confidence', default=0.5, type=float,
+                        help='Class confidence')
+    parser.add_argument('--nms', default=0.5, type=float,
+                        help='Enter nms IOU threshold')
+    parser.add_argument('--obj', default=0.5, type=float,
+                        help='Enter object threshold')
+    parser.add_argument('--save', '-s', action='store_true',
+                        help='Specify to save results. This flag is invalid when using camera.')
+    parser.add_argument('--vis', '-v', action='store_true',
+                        help='Specify to open a window for result visualization. This flag is invalid when using camera.')
     args = parser.parse_args()
 
     backend_id = backend_target_pairs[args.backend_target][0]
     target_id = backend_target_pairs[args.backend_target][1]
 
-    model_net = YoloX(
-        modelPath=args.model,
-        confThreshold=args.confidence,
-        nmsThreshold=args.nms,
-        objThreshold=args.obj,
-        backendId=backend_id,
-        targetId=target_id,
-    )
+    model_net = YoloX(modelPath= args.model,
+                      confThreshold=args.confidence,
+                      nmsThreshold=args.nms,
+                      objThreshold=args.obj,
+                      backendId=backend_id,
+                      targetId=target_id)
 
     tm = cv.TickMeter()
     tm.reset()
@@ -237,8 +121,8 @@ if __name__ == "__main__":
         img = vis(preds, image, letterbox_scale)
 
         if args.save:
-            print("Results saved to result.jpg\n")
-            cv.imwrite("result.jpg", img)
+            print('Results saved to result.jpg\n')
+            cv.imwrite('result.jpg', img)
 
         if args.vis:
             cv.namedWindow(args.input, cv.WINDOW_AUTOSIZE)
@@ -253,7 +137,7 @@ if __name__ == "__main__":
         while cv.waitKey(1) < 0:
             hasFrame, frame = cap.read()
             if not hasFrame:
-                print("No frames grabbed!")
+                print('No frames grabbed!')
                 break
 
             input_blob = cv.cvtColor(frame, cv.COLOR_BGR2RGB)

--- a/models/object_detection_yolox/demo.py
+++ b/models/object_detection_yolox/demo.py
@@ -58,12 +58,12 @@ def vis(dets, srcimg, letterbox_scale, fps=None):
         score = det[-2]
         cls_id = int(det[-1])
 
-        x0, y0, x1, y1 = box
+        x0, y0, w, h = box
 
         text = '{}:{:.1f}%'.format(classes[cls_id], score * 100)
         font = cv.FONT_HERSHEY_SIMPLEX
         txt_size = cv.getTextSize(text, font, 0.4, 1)[0]
-        cv.rectangle(res_img, (x0, y0), (x1, y1), (0, 255, 0), 2)
+        cv.rectangle(res_img, (x0, y0 , w, h), (0, 255, 0), 2)
         cv.rectangle(res_img, (x0, y0 + 1), (x0 + txt_size[0] + 1, y0 + int(1.5 * txt_size[1])), (255, 255, 255), -1)
         cv.putText(res_img, text, (x0, y0 + txt_size[1]), font, 0.4, (0, 0, 0), thickness=1)
 

--- a/models/object_detection_yolox/yolox.py
+++ b/models/object_detection_yolox/yolox.py
@@ -50,20 +50,20 @@ class YoloX:
 
         # get boxes
         boxes = dets[:, :4]
-        boxes_xyxy = np.ones_like(boxes)
-        boxes_xyxy[:, 0] = boxes[:, 0] - boxes[:, 2] / 2.
-        boxes_xyxy[:, 1] = boxes[:, 1] - boxes[:, 3] / 2.
-        boxes_xyxy[:, 2] = boxes[:, 0] + boxes[:, 2] / 2.
-        boxes_xyxy[:, 3] = boxes[:, 1] + boxes[:, 3] / 2.
+        boxes_xywh = np.ones_like(boxes)
+        boxes_xywh[:, 0] = boxes[:, 0] - boxes[:, 2] / 2.
+        boxes_xywh[:, 1] = boxes[:, 1] - boxes[:, 3] / 2.
+        boxes_xywh[:, 2] = boxes[:, 2]
+        boxes_xywh[:, 3] = boxes[:, 3]
 
         # get scores and class indices
         scores = dets[:, 4:5] * dets[:, 5:]
         max_scores = np.amax(scores, axis=1)
         max_scores_idx = np.argmax(scores, axis=1)
 
-        keep = cv2.dnn.NMSBoxesBatched(boxes_xyxy.tolist(), max_scores.tolist(), max_scores_idx.tolist(), self.confThreshold, self.nmsThreshold)
+        keep = cv2.dnn.NMSBoxesBatched(boxes_xywh.tolist(), max_scores.tolist(), max_scores_idx.tolist(), self.confThreshold, self.nmsThreshold)
 
-        candidates = np.concatenate([boxes_xyxy, max_scores[:, None], max_scores_idx[:, None]], axis=1)
+        candidates = np.concatenate([boxes_xywh, max_scores[:, None], max_scores_idx[:, None]], axis=1)
         if len(keep) == 0:
             return np.array([])
         return candidates[keep]

--- a/models/object_detection_yolox/yolox.py
+++ b/models/object_detection_yolox/yolox.py
@@ -1,8 +1,17 @@
 import numpy as np
 import cv2
 
+
 class YoloX:
-    def __init__(self, modelPath, confThreshold=0.35, nmsThreshold=0.5, objThreshold=0.5, backendId=0, targetId=0):
+    def __init__(
+        self,
+        modelPath,
+        confThreshold=0.35,
+        nmsThreshold=0.5,
+        objThreshold=0.5,
+        backendId=0,
+        targetId=0,
+    ):
         self.num_classes = 80
         self.net = cv2.dnn.readNet(modelPath)
         self.input_size = (640, 640)
@@ -50,20 +59,28 @@ class YoloX:
 
         # get boxes
         boxes = dets[:, :4]
-        boxes_xyxy = np.ones_like(boxes)
-        boxes_xyxy[:, 0] = boxes[:, 0] - boxes[:, 2] / 2.
-        boxes_xyxy[:, 1] = boxes[:, 1] - boxes[:, 3] / 2.
-        boxes_xyxy[:, 2] = boxes[:, 0] + boxes[:, 2] / 2.
-        boxes_xyxy[:, 3] = boxes[:, 1] + boxes[:, 3] / 2.
+        boxes_xywh = np.ones_like(boxes)
+        boxes_xywh[:, 0] = boxes[:, 0] - boxes[:, 2] / 2.0
+        boxes_xywh[:, 1] = boxes[:, 1] - boxes[:, 3] / 2.0
+        boxes_xywh[:, 2] = boxes[:, 2]
+        boxes_xywh[:, 3] = boxes[:, 3]
 
         # get scores and class indices
         scores = dets[:, 4:5] * dets[:, 5:]
         max_scores = np.amax(scores, axis=1)
         max_scores_idx = np.argmax(scores, axis=1)
 
-        keep = cv2.dnn.NMSBoxesBatched(boxes_xyxy.tolist(), max_scores.tolist(), max_scores_idx.tolist(), self.confThreshold, self.nmsThreshold)
+        keep = cv2.dnn.NMSBoxesBatched(
+            boxes_xywh.tolist(),
+            max_scores.tolist(),
+            max_scores_idx.tolist(),
+            self.confThreshold,
+            self.nmsThreshold,
+        )
 
-        candidates = np.concatenate([boxes_xyxy, max_scores[:, None], max_scores_idx[:, None]], axis=1)
+        candidates = np.concatenate(
+            [boxes_xywh, max_scores[:, None], max_scores_idx[:, None]], axis=1
+        )
         if len(keep) == 0:
             return np.array([])
         return candidates[keep]


### PR DESCRIPTION
NMSBoxesBatched function should accept OpenCV's Rect objects instead of two diagonal corner coordinates.

xyxy accept:
![result_xyxy](https://github.com/user-attachments/assets/08d60c40-334e-4e7c-9ad3-756ebed617ca)

xywh (Rect) accept:
![result_xywh](https://github.com/user-attachments/assets/49d44bca-c55e-4902-af4e-76c21f1279e8)
