### PR TITLE
add Face detection model with dynamic input for OpenCV 5.x ORT engine

### DIFF
--- a/models/face_detection_yunet/README.md
+++ b/models/face_detection_yunet/README.md
@@ -7,7 +7,8 @@ Notes:
 - Model source: [here](https://github.com/ShiqiYu/libfacedetection.train/blob/a61a428929148171b488f024b5d6774f93cdbc13/tasks/task1/onnx/yunet.onnx).
 - This model can detect **faces of pixels between around 10x10 to 300x300** due to the training scheme.
 - For details on training this model, please visit https://github.com/ShiqiYu/libfacedetection.train.
-- This ONNX model has fixed input shape, but OpenCV DNN infers on the exact shape of input image. See https://github.com/opencv/opencv_zoo/issues/44 for more information.
+- `face_detection_yunet_2026may.onnx` is the default model with **dynamic input shape** (symbolic `height` and `width` dims), compatible with OpenCV 5.x ONNX Runtime engine (`OPENCV_FORCE_DNN_ENGINE=4`). It is re-exported from `face_detection_yunet_2023mar.onnx` with static H/W dims replaced by symbolic dims, allowing inference at any resolution without resizing.
+- `face_detection_yunet_2023mar.onnx` has fixed input shape. OpenCV 4.x DNN infers on the exact shape of input image, but the ONNX Runtime engine in OpenCV 5.x requires dynamic dims for variable input sizes. See https://github.com/opencv/opencv_zoo/issues/44 for more information.
 - `face_detection_yunet_2023mar_int8bq.onnx` represents the block-quantized version in int8 precision and is generated using [block_quantize.py](../../tools/quantize/block_quantize.py) with `block_size=64`.
 - Paper source: [Yunet: A tiny millisecond-level face detector](https://link.springer.com/article/10.1007/s11633-023-1423-y).
 

--- a/models/face_detection_yunet/demo.cpp
+++ b/models/face_detection_yunet/demo.cpp
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
     cv::CommandLineParser parser(argc, argv,
         "{help  h           |                                   | Print this message}"
         "{input i           |                                   | Set input to a certain image, omit if using camera}"
-        "{model m           | face_detection_yunet_2023mar.onnx  | Set path to the model}"
+        "{model m           | face_detection_yunet_2026may.onnx  | Set path to the model}"
         "{backend b         | opencv                            | Set DNN backend}"
         "{target t          | cpu                               | Set DNN target}"
         "{save s            | false                             | Whether to save result image or not}"

--- a/models/face_detection_yunet/demo.py
+++ b/models/face_detection_yunet/demo.py
@@ -28,8 +28,8 @@ backend_target_pairs = [
 parser = argparse.ArgumentParser(description='YuNet: A Fast and Accurate CNN-based Face Detector (https://github.com/ShiqiYu/libfacedetection).')
 parser.add_argument('--input', '-i', type=str,
                     help='Usage: Set input to a certain image, omit if using camera.')
-parser.add_argument('--model', '-m', type=str, default='face_detection_yunet_2023mar.onnx',
-                    help="Usage: Set model type, defaults to 'face_detection_yunet_2023mar.onnx'.")
+parser.add_argument('--model', '-m', type=str, default='face_detection_yunet_2026may.onnx',
+                    help="Usage: Set model type, defaults to 'face_detection_yunet_2026may.onnx'.")
 parser.add_argument('--backend_target', '-bt', type=int, default=0,
                     help='''Choose one of the backend-target pair to run this demo:
                         {:d}: (default) OpenCV implementation + CPU,

--- a/models/face_detection_yunet/face_detection_yunet_2026may.onnx
+++ b/models/face_detection_yunet/face_detection_yunet_2026may.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebafce4e3c118d6554634be5c27ab333b4c047a9a8c3faf1d7cf93101c22f0f0
+size 229738


### PR DESCRIPTION

Add `face_detection_yunet_2026may.onnx` — re-exported from `face_detection_yunet_2023mar.onnx`
with H and W input dims replaced by symbolic `height`/`width`, making it compatible
with ORT at any resolution. 

## Changes
- Add `face_detection_yunet_2026may.onnx` (dynamic input, FP32)
- Update default model in `demo.py` and `demo.cpp` to `face_detection_yunet_2026may.onnx`
- Update `README.md` to document the dynamic vs static distinction

Companion PR : https://github.com/opencv/opencv/pull/29107